### PR TITLE
Make API key optional for public model endpoints

### DIFF
--- a/skills/openrouter-models/SKILL.md
+++ b/skills/openrouter-models/SKILL.md
@@ -9,7 +9,7 @@ Discover, search, and compare the 300+ AI models available on OpenRouter. Query 
 
 ## Prerequisites
 
-The `OPENROUTER_API_KEY` environment variable must be set. Get a key at https://openrouter.ai/keys
+The `OPENROUTER_API_KEY` environment variable is optional for most scripts. It is only required for `get-endpoints.ts` (provider performance data). Get a key at https://openrouter.ai/keys
 
 ## First-Time Setup
 

--- a/skills/openrouter-models/scripts/compare-models.ts
+++ b/skills/openrouter-models/scripts/compare-models.ts
@@ -1,6 +1,6 @@
-import { requireApiKey, fetchApi, parseArgs } from "./lib.js";
+import { optionalApiKey, fetchApi, parseArgs } from "./lib.js";
 
-const apiKey = requireApiKey();
+const apiKey = optionalApiKey();
 const args = parseArgs(process.argv.slice(2));
 const sortBy = args.get("sort") as string | undefined;
 

--- a/skills/openrouter-models/scripts/lib.ts
+++ b/skills/openrouter-models/scripts/lib.ts
@@ -10,11 +10,17 @@ export function requireApiKey(): string {
   return apiKey;
 }
 
-export async function fetchApi(path: string, apiKey: string): Promise<any> {
+export function optionalApiKey(): string | undefined {
+  return process.env.OPENROUTER_API_KEY;
+}
+
+export async function fetchApi(path: string, apiKey?: string): Promise<any> {
   const url = `https://openrouter.ai/api/v1${path}`;
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${apiKey}` },
-  });
+  const headers: Record<string, string> = {};
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  const res = await fetch(url, { headers });
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");

--- a/skills/openrouter-models/scripts/list-models.ts
+++ b/skills/openrouter-models/scripts/list-models.ts
@@ -1,6 +1,6 @@
-import { requireApiKey, fetchApi, formatModel, parseArgs } from "./lib.js";
+import { optionalApiKey, fetchApi, formatModel, parseArgs } from "./lib.js";
 
-const apiKey = requireApiKey();
+const apiKey = optionalApiKey();
 const args = parseArgs(process.argv.slice(2));
 const category = args.get("category") as string | undefined;
 const sort = args.get("sort") as string | undefined;

--- a/skills/openrouter-models/scripts/resolve-model.ts
+++ b/skills/openrouter-models/scripts/resolve-model.ts
@@ -1,4 +1,4 @@
-import { requireApiKey, fetchApi, formatModel, parseArgs } from "./lib.js";
+import { optionalApiKey, fetchApi, formatModel, parseArgs } from "./lib.js";
 
 const STOP_WORDS = new Set([
   "the", "a", "an", "model", "latest", "best", "from", "by", "most", "for",
@@ -109,7 +109,7 @@ function confidence(score: number): "high" | "medium" | "low" {
 
 // --- main ---
 
-const apiKey = requireApiKey();
+const apiKey = optionalApiKey();
 const args = parseArgs(process.argv.slice(2));
 const rawQuery = args.get("_0") as string | undefined;
 

--- a/skills/openrouter-models/scripts/search-models.ts
+++ b/skills/openrouter-models/scripts/search-models.ts
@@ -1,6 +1,6 @@
-import { requireApiKey, fetchApi, formatModel, parseArgs } from "./lib.js";
+import { optionalApiKey, fetchApi, formatModel, parseArgs } from "./lib.js";
 
-const apiKey = requireApiKey();
+const apiKey = optionalApiKey();
 const args = parseArgs(process.argv.slice(2));
 const query = args.get("_0") as string | undefined;
 const modality = args.get("modality") as string | undefined;


### PR DESCRIPTION
## Summary

- Add `optionalApiKey()` helper to lib.ts alongside existing `requireApiKey()`
- Make `fetchApi()` accept an optional API key (sends unauthenticated requests when absent)
- Switch `list-models`, `search-models`, `resolve-model`, and `compare-models` to use `optionalApiKey()`
- `get-endpoints` still requires auth via `requireApiKey()` since the `/endpoints` route needs it
- Update SKILL.md prerequisites to reflect the change

## Test plan

- [ ] Run `list-models.ts` without `OPENROUTER_API_KEY` set — should return models
- [ ] Run `get-endpoints.ts` without `OPENROUTER_API_KEY` set — should error with clear message