### PR TITLE
feat: add openrouter-agent-migration skill

### DIFF
--- a/skills/openrouter-agent-migration/SKILL.md
+++ b/skills/openrouter-agent-migration/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: openrouter-agent-migration
+description: Migration guide from @openrouter/sdk to @openrouter/agent for callModel, tool(), stop conditions, and agent features. This skill should be used when code imports callModel, tool(), or stop conditions from @openrouter/sdk and needs to migrate to @openrouter/agent.
+version: 1.0.0
+---
+
+# Migrating from @openrouter/sdk to @openrouter/agent
+
+Agent functionality (`callModel`, `tool()`, stop conditions, format converters, streaming helpers) has moved from `@openrouter/sdk` to the standalone `@openrouter/agent` package. The `@openrouter/agent` package includes its own `OpenRouter` client class, so you do not need `@openrouter/sdk` for agent use cases.
+
+---
+
+## When This Applies
+
+Migrate if your code imports any of these from `@openrouter/sdk`:
+
+- `callModel` or uses `client.callModel()`
+- `tool()` factory function
+- Stop conditions: `stepCountIs`, `hasToolCall`, `maxCost`, `maxTokensUsed`, `finishReasonIs`
+- Format converters: `fromClaudeMessages`, `toClaudeMessage`, `fromChatMessages`, `toChatMessage`
+- Types: `Tool`, `ToolWithExecute`, `ToolWithGenerator`, `ManualTool`, `CallModelInput`, `ModelResult`
+
+---
+
+## Quick Migration
+
+### Step 1: Install
+
+```bash
+npm install @openrouter/agent
+```
+
+If you only use agent features, you can remove `@openrouter/sdk`:
+
+```bash
+npm uninstall @openrouter/sdk
+npm install @openrouter/agent
+```
+
+If you also use non-agent SDK features (models list, chat completions, credits, OAuth, API keys), keep both packages installed.
+
+### Step 2: Update Imports
+
+The `OpenRouter` client class and `client.callModel()` pattern work identically. Only the import source changes:
+
+```diff
+- import OpenRouter from '@openrouter/sdk';
++ import { OpenRouter } from '@openrouter/agent';
+```
+
+The rest of your code stays the same:
+
+```typescript
+const client = new OpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
+
+const result = client.callModel({
+  model: 'openai/gpt-5-nano',
+  input: 'Hello!',
+});
+
+const text = await result.getText();
+```
+
+---
+
+## Complete Import Mapping
+
+### Client & callModel
+
+| Old | New |
+|-----|-----|
+| `import OpenRouter from '@openrouter/sdk'` | `import { OpenRouter } from '@openrouter/agent'` |
+| `import OpenRouter, { tool, stepCountIs } from '@openrouter/sdk'` | `import { OpenRouter } from '@openrouter/agent'`<br>`import { tool } from '@openrouter/agent/tool'`<br>`import { stepCountIs } from '@openrouter/agent/stop-conditions'` |
+
+A standalone `callModel` function is also available for advanced use cases where a pre-existing `OpenRouterCore` instance is available:
+
+```typescript
+import { callModel } from '@openrouter/agent/call-model';
+
+// Requires an OpenRouterCore instance (from @openrouter/sdk/core)
+const result = callModel(coreInstance, { model: 'openai/gpt-5-nano', input: 'Hello' });
+```
+
+For most use cases, prefer the `client.callModel()` method shown above.
+
+### Tool Creation
+
+| Old | New |
+|-----|-----|
+| `import { tool } from '@openrouter/sdk'` | `import { tool } from '@openrouter/agent/tool'` |
+
+### Stop Conditions
+
+| Old | New |
+|-----|-----|
+| `import { stepCountIs, hasToolCall, maxCost } from '@openrouter/sdk'` | `import { stepCountIs, hasToolCall, maxCost } from '@openrouter/agent/stop-conditions'` |
+| `import { maxTokensUsed, finishReasonIs } from '@openrouter/sdk'` | `import { maxTokensUsed, finishReasonIs } from '@openrouter/agent/stop-conditions'` |
+
+### Types
+
+| Old | New |
+|-----|-----|
+| `import type { Tool, ToolWithExecute, ToolWithGenerator, ManualTool } from '@openrouter/sdk/lib/tool-types'` | `import type { Tool, ToolWithExecute, ToolWithGenerator, ManualTool } from '@openrouter/agent/tool-types'` |
+| `import type { CallModelInput } from '@openrouter/sdk/lib/async-params'` | `import type { CallModelInput } from '@openrouter/agent/async-params'` |
+| `import { ModelResult } from '@openrouter/sdk/lib/model-result'` | `import { ModelResult } from '@openrouter/agent/model-result'` |
+
+### Format Converters
+
+| Old | New |
+|-----|-----|
+| `import { fromClaudeMessages, toClaudeMessage } from '@openrouter/sdk'` | `import { fromClaudeMessages, toClaudeMessage } from '@openrouter/agent'` |
+| `import { fromChatMessages, toChatMessage } from '@openrouter/sdk'` | `import { fromChatMessages, toChatMessage } from '@openrouter/agent'` |
+
+### Type Guards
+
+| Old | New |
+|-----|-----|
+| `import { hasExecuteFunction, isGeneratorTool, isRegularExecuteTool } from '@openrouter/sdk'` | `import { hasExecuteFunction, isGeneratorTool, isRegularExecuteTool } from '@openrouter/agent/tool-types'` |
+
+---
+
+## Before & After Example
+
+### Before (using @openrouter/sdk)
+
+```typescript
+import OpenRouter, { tool, stepCountIs, hasToolCall } from '@openrouter/sdk';
+import { z } from 'zod';
+
+const client = new OpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const searchTool = tool({
+  name: 'web_search',
+  description: 'Search the web',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.object({ results: z.array(z.string()) }),
+  execute: async ({ query }) => {
+    return { results: ['Result 1', 'Result 2'] };
+  },
+});
+
+const finishTool = tool({
+  name: 'finish',
+  description: 'Complete the task',
+  inputSchema: z.object({ answer: z.string() }),
+  execute: async ({ answer }) => ({ answer }),
+});
+
+const result = client.callModel({
+  model: 'openai/gpt-5-nano',
+  instructions: 'You are a research assistant.',
+  input: 'What are the latest AI developments?',
+  tools: [searchTool, finishTool],
+  stopWhen: [stepCountIs(10), hasToolCall('finish')],
+});
+
+const text = await result.getText();
+```
+
+### After (using @openrouter/agent)
+
+```typescript
+import { OpenRouter } from '@openrouter/agent';
+import { tool } from '@openrouter/agent/tool';
+import { stepCountIs, hasToolCall } from '@openrouter/agent/stop-conditions';
+import { z } from 'zod';
+
+const client = new OpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const searchTool = tool({
+  name: 'web_search',
+  description: 'Search the web',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.object({ results: z.array(z.string()) }),
+  execute: async ({ query }) => {
+    return { results: ['Result 1', 'Result 2'] };
+  },
+});
+
+const finishTool = tool({
+  name: 'finish',
+  description: 'Complete the task',
+  inputSchema: z.object({ answer: z.string() }),
+  execute: async ({ answer }) => ({ answer }),
+});
+
+const result = client.callModel({
+  model: 'openai/gpt-5-nano',
+  instructions: 'You are a research assistant.',
+  input: 'What are the latest AI developments?',
+  tools: [searchTool, finishTool],
+  stopWhen: [stepCountIs(10), hasToolCall('finish')],
+});
+
+const text = await result.getText();
+```
+
+The only changes are the three import lines at the top.
+
+---
+
+## When to Keep @openrouter/sdk
+
+Keep `@openrouter/sdk` installed if you use any of these non-agent features:
+
+| Feature | Access |
+|---------|--------|
+| Model listing | `client.models.list()` |
+| Chat completions | `client.chat.send()` |
+| Legacy completions | `client.completions.generate()` |
+| Usage analytics | `client.analytics.getUserActivity()` |
+| Credit balance | `client.credits.getCredits()` |
+| API key management | `client.apiKeys.list()`, `.create()`, etc. |
+| OAuth PKCE flow | `client.oAuth.createAuthCode()`, `.exchangeAuthCodeForAPIKey()` |
+
+For mixed projects, use `@openrouter/sdk` for these features and `@openrouter/agent` for agent features:
+
+```typescript
+import OpenRouter from '@openrouter/sdk';               // SDK client for models, credits, etc.
+import { OpenRouter as Agent } from '@openrouter/agent'; // Agent client for callModel
+import { tool } from '@openrouter/agent/tool';
+import { stepCountIs } from '@openrouter/agent/stop-conditions';
+
+// Use SDK client for non-agent features
+const sdkClient = new OpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
+const models = await sdkClient.models.list();
+const credits = await sdkClient.credits.getCredits();
+
+// Use Agent client for callModel
+const agent = new Agent({ apiKey: process.env.OPENROUTER_API_KEY });
+const result = agent.callModel({
+  model: 'openai/gpt-5-nano',
+  input: 'Hello!',
+  tools: [myTool],
+  stopWhen: stepCountIs(5),
+});
+```
+
+---
+
+## New Features in @openrouter/agent
+
+These features are only available in `@openrouter/agent`, not in `@openrouter/sdk`:
+
+### Shared Context Schema
+
+Type-safe shared state across all tools in a conversation:
+
+```typescript
+import { OpenRouter } from '@openrouter/agent';
+import { z } from 'zod';
+
+const client = new OpenRouter({ apiKey: '...' });
+
+const result = client.callModel({
+  model: 'openai/gpt-5-nano',
+  input: 'Process this data',
+  sharedContextSchema: z.object({
+    userId: z.string(),
+    sessionData: z.record(z.unknown()),
+  }),
+  context: {
+    shared: { userId: '123', sessionData: {} },
+  },
+  tools: [myTool],
+});
+```
+
+### Tool Context
+
+Tools can declare their own typed context and access shared context:
+
+```typescript
+import { tool } from '@openrouter/agent/tool';
+import { z } from 'zod';
+
+const myTool = tool({
+  name: 'my_tool',
+  description: 'A tool with context',
+  inputSchema: z.object({ query: z.string() }),
+  contextSchema: z.object({ apiKey: z.string() }),
+  execute: async (params, context) => {
+    // context.local — this tool's own context
+    // context.shared — shared context across all tools
+    // context.setContext({ ... }) — update this tool's context
+    // context.setSharedContext({ ... }) — update shared context
+    return { result: 'done' };
+  },
+});
+```
+
+### Tool Approval Flow
+
+Require user approval before tool execution:
+
+```typescript
+const dangerousTool = tool({
+  name: 'delete_file',
+  description: 'Delete a file',
+  inputSchema: z.object({ path: z.string() }),
+  requireApproval: true, // or a function: (toolCall, context) => boolean
+  execute: async ({ path }) => { /* ... */ },
+});
+```
+
+### Turn Lifecycle Callbacks
+
+```typescript
+const result = client.callModel({
+  model: 'openai/gpt-5-nano',
+  input: 'Complex task',
+  tools: [myTool],
+  onTurnStart: async (context) => {
+    console.log(`Starting turn ${context.numberOfTurns}`);
+  },
+  onTurnEnd: async (context, response) => {
+    console.log(`Turn ${context.numberOfTurns} complete`);
+  },
+});
+```
+
+---
+
+## All Subpath Exports
+
+`@openrouter/agent` provides granular subpath imports:
+
+| Subpath | Exports |
+|---------|---------|
+| `@openrouter/agent` | Barrel: all exports below |
+| `@openrouter/agent/client` | `OpenRouter` class |
+| `@openrouter/agent/call-model` | `callModel` standalone function |
+| `@openrouter/agent/tool` | `tool()` factory function |
+| `@openrouter/agent/tool-types` | `Tool`, `ToolWithExecute`, `ToolWithGenerator`, `ManualTool`, type guards |
+| `@openrouter/agent/stop-conditions` | `stepCountIs`, `hasToolCall`, `maxCost`, `maxTokensUsed`, `finishReasonIs` |
+| `@openrouter/agent/model-result` | `ModelResult` response wrapper |
+| `@openrouter/agent/async-params` | `CallModelInput`, `hasAsyncFunctions`, `resolveAsyncFunctions` |
+| `@openrouter/agent/anthropic-compat` | `fromClaudeMessages`, `toClaudeMessage` |
+| `@openrouter/agent/chat-compat` | `fromChatMessages`, `toChatMessage` |
+| `@openrouter/agent/conversation-state` | `createInitialState`, `updateState`, `appendToMessages` |
+| `@openrouter/agent/next-turn-params` | `nextTurnParams` utilities |
+| `@openrouter/agent/stream-transformers` | `extractUnsupportedContent`, `getUnsupportedContentSummary` |
+| `@openrouter/agent/tool-context` | `buildToolExecuteContext`, `ToolContextStore` |
+| `@openrouter/agent/tool-event-broadcaster` | `ToolEventBroadcaster` |
+| `@openrouter/agent/turn-context` | `buildTurnContext` |
+

--- a/skills/openrouter-agent-migration/metadata.json
+++ b/skills/openrouter-agent-migration/metadata.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0.0",
+  "organization": "OpenRouter Inc",
+  "date": "March 2026",
+  "abstract": "Migration guide for moving agent functionality (callModel, tool(), stop conditions, format converters, streaming helpers) from @openrouter/sdk to the standalone @openrouter/agent package. Covers import mapping, before/after examples, mixed-project patterns, and new agent-only features like shared context, tool approval, and turn lifecycle callbacks.",
+  "references": [
+    "https://github.com/OpenRouterTeam/openrouter-web/pull/16805",
+    "https://github.com/OpenRouterTeam/openrouter-web/pull/16953",
+    "https://openrouter.ai/docs/sdks/typescript/call-model/overview"
+  ]
+}

--- a/skills/openrouter-typescript-sdk/SKILL.md
+++ b/skills/openrouter-typescript-sdk/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: openrouter-typescript-sdk
-description: Complete reference for integrating with 300+ AI models through the OpenRouter TypeScript SDK using the callModel pattern
-version: 1.0.0
+description: Complete reference for integrating with 300+ AI models through the OpenRouter TypeScript SDK and Agent packages using the callModel pattern
+version: 2.0.0
 ---
 
 # OpenRouter TypeScript SDK
 
 A comprehensive TypeScript SDK for interacting with OpenRouter's unified API, providing access to 300+ AI models through a single, type-safe interface. This skill enables AI agents to leverage the `callModel` pattern for text generation, tool usage, streaming, and multi-turn conversations.
 
+The SDK is split into two packages:
+- **`@openrouter/agent`** — Agent features: `callModel`, `tool()`, stop conditions, streaming, format converters
+- **`@openrouter/sdk`** — Platform features: model listing, chat completions, credits, OAuth, API key management
+
 ---
 
 ## Installation
 
 ```bash
+# For agent features (callModel, tools, stop conditions)
+npm install @openrouter/agent
+
+# For platform features (models, credits, OAuth, API keys)
 npm install @openrouter/sdk
 ```
 
@@ -21,7 +29,7 @@ npm install @openrouter/sdk
 Get your API key from [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys), then initialize:
 
 ```typescript
-import OpenRouter from '@openrouter/sdk';
+import { OpenRouter } from '@openrouter/agent';
 
 const client = new OpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY
@@ -53,7 +61,7 @@ export OPENROUTER_API_KEY=sk-or-v1-your-key-here
 #### Client Initialization
 
 ```typescript
-import OpenRouter from '@openrouter/sdk';
+import { OpenRouter } from '@openrouter/agent';
 
 const client = new OpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY
@@ -72,10 +80,13 @@ const result = client.callModel({
 
 #### Get Current Key Metadata
 
-Retrieve information about the currently configured API key:
+Retrieve information about the currently configured API key (requires `@openrouter/sdk`):
 
 ```typescript
-const keyInfo = await client.apiKeys.getCurrentKeyMetadata();
+import OpenRouter from '@openrouter/sdk';
+const sdkClient = new OpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
+
+const keyInfo = await sdkClient.apiKeys.getCurrentKeyMetadata();
 console.log('Key name:', keyInfo.name);
 console.log('Created:', keyInfo.createdAt);
 ```
@@ -180,11 +191,13 @@ await saveUserApiKey(userId, userApiKey);
 
 ```typescript
 import OpenRouter from '@openrouter/sdk';
+import { OpenRouter as Agent } from '@openrouter/agent';
 import express from 'express';
 
 const app = express();
+// SDK client for OAuth and API key management
 const client = new OpenRouter({
-  apiKey: process.env.OPENROUTER_API_KEY  // Your app's key for OAuth operations
+  apiKey: process.env.OPENROUTER_API_KEY
 });
 
 // Step 1: Initiate OAuth flow
@@ -227,12 +240,12 @@ app.get('/auth/callback', async (req, res) => {
 app.post('/api/chat', async (req, res) => {
   const userApiKey = await getUserApiKey(req.session.userId);
 
-  // Create a client with the user's key
-  const userClient = new OpenRouter({
+  // Create an agent client with the user's key
+  const userAgent = new Agent({
     apiKey: userApiKey
   });
 
-  const result = userClient.callModel({
+  const result = userAgent.callModel({
     model: 'openai/gpt-5-nano',
     input: req.body.message
   });
@@ -395,7 +408,7 @@ Create strongly-typed tools using Zod schemas for automatic validation and type 
 ### Defining Tools
 
 ```typescript
-import { tool } from '@openrouter/sdk';
+import { tool } from '@openrouter/agent/tool';
 import { z } from 'zod';
 
 const weatherTool = tool({
@@ -492,7 +505,7 @@ const manualTool = tool({
 Control automatic tool execution with stop conditions:
 
 ```typescript
-import { stepCountIs, maxCost, hasToolCall } from '@openrouter/sdk';
+import { stepCountIs, maxCost, hasToolCall } from '@openrouter/agent/stop-conditions';
 
 const result = client.callModel({
   model: 'openai/gpt-5.2',
@@ -655,7 +668,7 @@ Convert between ecosystem formats for interoperability:
 ### OpenAI Format
 
 ```typescript
-import { fromChatMessages, toChatMessage } from '@openrouter/sdk';
+import { fromChatMessages, toChatMessage } from '@openrouter/agent';
 
 // OpenAI messages → OpenRouter format
 const result = client.callModel({
@@ -671,7 +684,7 @@ const chatMsg = toChatMessage(response);
 ### Claude Format
 
 ```typescript
-import { fromClaudeMessages, toClaudeMessage } from '@openrouter/sdk';
+import { fromClaudeMessages, toClaudeMessage } from '@openrouter/agent';
 
 // Claude messages → OpenRouter format
 const result = client.callModel({
@@ -1040,36 +1053,38 @@ for await (const message of result.getNewMessagesStream()) {
 
 ### Client Methods
 
-Beyond `callModel`, the client provides access to other API endpoints:
+Beyond `callModel`, the SDK client (`@openrouter/sdk`) provides access to platform API endpoints:
 
 ```typescript
-const client = new OpenRouter({
+import OpenRouter from '@openrouter/sdk';
+
+const sdkClient = new OpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY
 });
 
 // List available models
-const models = await client.models.list();
+const models = await sdkClient.models.list();
 
 // Chat completions (alternative to callModel)
-const completion = await client.chat.send({
+const completion = await sdkClient.chat.send({
   model: 'openai/gpt-5-nano',
   messages: [{ role: 'user', content: 'Hello!' }]
 });
 
 // Legacy completions format
-const legacyCompletion = await client.completions.generate({
+const legacyCompletion = await sdkClient.completions.generate({
   model: 'openai/gpt-5-nano',
   prompt: 'Once upon a time'
 });
 
 // Usage analytics
-const activity = await client.analytics.getUserActivity();
+const activity = await sdkClient.analytics.getUserActivity();
 
 // Credit balance
-const credits = await client.credits.getCredits();
+const credits = await sdkClient.credits.getCredits();
 
 // API key management
-const keys = await client.apiKeys.list();
+const keys = await sdkClient.apiKeys.list();
 ```
 
 ---
@@ -1116,7 +1131,9 @@ try {
 ## Complete Example: Agent with Tools
 
 ```typescript
-import OpenRouter, { tool, stepCountIs } from '@openrouter/sdk';
+import { OpenRouter } from '@openrouter/agent';
+import { tool } from '@openrouter/agent/tool';
+import { stepCountIs, hasToolCall } from '@openrouter/agent/stop-conditions';
 import { z } from 'zod';
 
 const client = new OpenRouter({
@@ -1242,7 +1259,8 @@ for await (const delta of result.getTextStream()) {
 
 - **API Keys**: [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
 - **Model List**: [openrouter.ai/models](https://openrouter.ai/models)
-- **GitHub Issues**: [github.com/OpenRouterTeam/typescript-sdk/issues](https://github.com/OpenRouterTeam/typescript-sdk/issues)
+- **Agent SDK**: [github.com/OpenRouterTeam/typescript-agent](https://github.com/OpenRouterTeam/typescript-agent)
+- **SDK Issues**: [github.com/OpenRouterTeam/typescript-sdk/issues](https://github.com/OpenRouterTeam/typescript-sdk/issues)
 
 ---
 

--- a/skills/openrouter-typescript-sdk/metadata.json
+++ b/skills/openrouter-typescript-sdk/metadata.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.0.0",
+  "version": "2.0.0",
   "organization": "OpenRouter Inc",
-  "date": "January 2026",
-  "abstract": "Complete reference for the OpenRouter TypeScript SDK, enabling AI agents to integrate with 300+ AI models through a unified, type-safe interface. Covers the callModel pattern for text generation, streaming, and multi-turn conversations with automatic tool execution. Includes detailed TypeScript interfaces for Responses API message shapes, streaming event types, authentication methods (API key and OAuth PKCE flow), Zod-based tool definitions, stop conditions, and format conversion helpers. Designed for AI agent consumption with production-ready examples and best practices.",
+  "date": "March 2026",
+  "abstract": "Complete reference for the OpenRouter TypeScript SDK and Agent packages, enabling AI agents to integrate with 300+ AI models through a unified, type-safe interface. Agent features (callModel, tool(), stop conditions, streaming, format converters) are in @openrouter/agent. Platform features (models, credits, OAuth, API keys) are in @openrouter/sdk. Covers the callModel pattern for text generation, streaming, and multi-turn conversations with automatic tool execution. Includes detailed TypeScript interfaces for Responses API message shapes, streaming event types, authentication methods, Zod-based tool definitions, and best practices.",
   "references": [
     "https://openrouter.ai/docs/sdks/typescript/call-model/overview",
     "https://openrouter.ai/docs/sdks",


### PR DESCRIPTION
## Summary
- Adds new `openrouter-agent-migration` skill with a complete migration guide from `@openrouter/sdk` to `@openrouter/agent`
- Updates existing `openrouter-typescript-sdk` skill to use `@openrouter/agent/*` imports for all agent-related code (callModel, tool, stop conditions, format converters)
- SDK-only features (models, credits, OAuth, API keys) remain referencing `@openrouter/sdk`

## Context
Based on [openrouter-web#16805](https://github.com/OpenRouterTeam/openrouter-web/pull/16805) (extract `@openrouter/agent` package) and [openrouter-web#16953](https://github.com/OpenRouterTeam/openrouter-web/pull/16953) (add `OpenRouter` client class to `@openrouter/agent`).

## Test plan
- [ ] Verify import paths match `@openrouter/agent` package.json exports
- [ ] Review migration skill triggers correctly when code uses `callModel` from `@openrouter/sdk`
- [ ] Confirm updated SDK skill examples compile with new import paths