### PR TITLE
Help agents with Response shapes

### DIFF
--- a/skills/openrouter-images/SKILL.md
+++ b/skills/openrouter-images/SKILL.md
@@ -95,6 +95,82 @@ Supported input formats: `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`
 }
 ```
 
+## API Response Shapes
+
+Image generation and editing use the Responses API with image modalities.
+
+### Request — Generate
+
+`POST https://openrouter.ai/api/v1/responses`
+
+```json
+{
+  "model": "google/gemini-3.1-flash-image-preview",
+  "input": [{ "role": "user", "content": "a red panda wearing sunglasses" }],
+  "modalities": ["image", "text"],
+  "image_config": {
+    "aspect_ratio": "16:9",
+    "image_size": "1K"
+  }
+}
+```
+
+`image_config` is optional — omit it (or individual fields) for model defaults.
+
+### Request — Edit
+
+Same endpoint. Send the source image as multimodal content:
+
+```json
+{
+  "model": "google/gemini-3.1-flash-image-preview",
+  "input": [{
+    "role": "user",
+    "content": [
+      { "type": "input_image", "image_url": "data:image/png;base64,...", "detail": "auto" },
+      { "type": "input_text", "text": "make the sky purple" }
+    ]
+  }],
+  "modalities": ["image", "text"],
+  "image_config": {}
+}
+```
+
+### Response
+
+```json
+{
+  "id": "resp-abc123",
+  "object": "response",
+  "status": "completed",
+  "model": "google/gemini-3.1-flash-image-preview",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg-abc123",
+      "role": "assistant",
+      "status": "completed",
+      "content": [{ "type": "output_text", "text": "Here is your image.", "annotations": [] }]
+    },
+    {
+      "type": "image_generation_call",
+      "id": "imagegen-abc123",
+      "status": "completed",
+      "result": "<base64-encoded image data>"
+    }
+  ],
+  "usage": {
+    "input_tokens": 50,
+    "output_tokens": 1200,
+    "total_tokens": 1250
+  }
+}
+```
+
+- Text appears in `message` output items as `output_text` content parts
+- Images appear as `image_generation_call` output items with base64 data in `result`
+- Either may be absent depending on the model and prompt
+
 ## Using a Different Model
 
 The default model is `google/gemini-3.1-flash-image-preview` (Nano Banana 2). To use a different model, pass `--model <id>` with any OpenRouter model ID that supports image output modalities.

--- a/skills/openrouter-images/SKILL.md
+++ b/skills/openrouter-images/SKILL.md
@@ -97,79 +97,20 @@ Supported input formats: `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`
 
 ## API Response Shapes
 
-Image generation and editing use the Responses API with image modalities.
+Image generation uses `POST /api/v1/responses` with `modalities: ["image", "text"]`. See the [Responses API reference](https://openrouter.ai/docs/api/reference/create-responses) and [image generation guide](https://openrouter.ai/docs/features/multimodal/image-generation) for full request details.
 
-### Request — Generate
-
-`POST https://openrouter.ai/api/v1/responses`
+The image-specific output item type is `image_generation_call` — this is not obvious from the general Responses API docs:
 
 ```json
 {
-  "model": "google/gemini-3.1-flash-image-preview",
-  "input": [{ "role": "user", "content": "a red panda wearing sunglasses" }],
-  "modalities": ["image", "text"],
-  "image_config": {
-    "aspect_ratio": "16:9",
-    "image_size": "1K"
-  }
-}
-```
-
-`image_config` is optional — omit it (or individual fields) for model defaults.
-
-### Request — Edit
-
-Same endpoint. Send the source image as multimodal content:
-
-```json
-{
-  "model": "google/gemini-3.1-flash-image-preview",
-  "input": [{
-    "role": "user",
-    "content": [
-      { "type": "input_image", "image_url": "data:image/png;base64,...", "detail": "auto" },
-      { "type": "input_text", "text": "make the sky purple" }
-    ]
-  }],
-  "modalities": ["image", "text"],
-  "image_config": {}
-}
-```
-
-### Response
-
-```json
-{
-  "id": "resp-abc123",
-  "object": "response",
+  "type": "image_generation_call",
+  "id": "imagegen-abc123",
   "status": "completed",
-  "model": "google/gemini-3.1-flash-image-preview",
-  "output": [
-    {
-      "type": "message",
-      "id": "msg-abc123",
-      "role": "assistant",
-      "status": "completed",
-      "content": [{ "type": "output_text", "text": "Here is your image.", "annotations": [] }]
-    },
-    {
-      "type": "image_generation_call",
-      "id": "imagegen-abc123",
-      "status": "completed",
-      "result": "<base64-encoded image data>"
-    }
-  ],
-  "usage": {
-    "input_tokens": 50,
-    "output_tokens": 1200,
-    "total_tokens": 1250
-  }
+  "result": "<base64-encoded image data>"
 }
 ```
 
-- Text appears in `message` output items as `output_text` content parts
-- Images appear as `image_generation_call` output items with base64 data in `result`
-- Either may be absent depending on the model and prompt
+This appears alongside standard `message` output items in the `output` array. Text and image outputs may each be absent depending on the model and prompt.
 
 ## Using a Different Model
 

--- a/skills/openrouter-images/SKILL.md
+++ b/skills/openrouter-images/SKILL.md
@@ -97,7 +97,7 @@ Supported input formats: `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`
 
 ## API Response Shapes
 
-Image generation uses `POST /api/v1/responses` with `modalities: ["image", "text"]`. See the [Responses API reference](https://openrouter.ai/docs/api/reference/create-responses) and [image generation guide](https://openrouter.ai/docs/features/multimodal/image-generation) for full request details.
+Image generation uses `POST /api/v1/responses` with `modalities: ["image", "text"]`. See the [Responses API reference](https://openrouter.ai/docs/api/reference/responses/overview) and [image generation guide](https://openrouter.ai/docs/guides/overview/multimodal/image-generation) for full request details.
 
 The image-specific output item type is `image_generation_call` — this is not obvious from the general Responses API docs:
 

--- a/skills/openrouter-models/SKILL.md
+++ b/skills/openrouter-models/SKILL.md
@@ -128,10 +128,7 @@ Returns for each provider:
 
 ## API Response Shapes
 
-For full field reference, see:
-- [List models](https://openrouter.ai/docs/api/reference/list-models) — `GET /api/v1/models`
-- [Get a model](https://openrouter.ai/docs/api/reference/get-a-model) — `GET /api/v1/models/{id}`
-- [Get model endpoints](https://openrouter.ai/docs/api/reference/get-model-endpoints) — `GET /api/v1/models/{id}/endpoints`
+For full field reference, see the [Models reference](https://openrouter.ai/docs/guides/overview/models).
 
 **Query parameters** for `GET /models` (all optional):
 
@@ -152,7 +149,7 @@ For full field reference, see:
 
 ## Script Output Formats
 
-The scripts below reformat the raw API data. When calling the API directly (e.g. via `fetch`), use the field names from the API Response Shapes section above.
+The scripts below reformat the raw API data. When calling the API directly (e.g. via `fetch`), refer to the [Models reference](https://openrouter.ai/docs/guides/overview/models) for field names.
 
 ### list-models.ts / search-models.ts
 

--- a/skills/openrouter-models/SKILL.md
+++ b/skills/openrouter-models/SKILL.md
@@ -128,9 +128,9 @@ Returns for each provider:
 
 ## API Response Shapes
 
-For full field reference, see the [Models reference](https://openrouter.ai/docs/guides/overview/models).
+`GET /api/v1/models` returns `{ data: Model[] }`. For full field reference, see the [Models reference](https://openrouter.ai/docs/guides/overview/models).
 
-**Query parameters** for `GET /models` (all optional):
+**Query parameters** (all optional):
 
 | Parameter | Example | Effect |
 |---|---|---|
@@ -143,7 +143,7 @@ For full field reference, see the [Models reference](https://openrouter.ai/docs/
 - To check modalities, use `model.architecture.input_modalities` / `model.architecture.output_modalities`.
 - Pricing values are per-token in USD as strings — multiply by 1,000,000 for per-million-token pricing.
 - `knowledge_cutoff` and `expiration_date` are date strings or null.
-- `links.details` points to the per-provider endpoints API for that model.
+- `links.details` points to the per-provider endpoints API for that model. `GET /api/v1/models/{author}/{slug}/endpoints` returns `{ data: { id, name, endpoints: Endpoint[] } }`.
 - Endpoint `status`: `0` = operational, non-zero = degraded.
 - Endpoint `latency_last_30m` / `throughput_last_30m`: percentile objects with `p50`, `p75`, `p90`, `p99`.
 
@@ -153,7 +153,7 @@ The scripts below reformat the raw API data. When calling the API directly (e.g.
 
 ### list-models.ts / search-models.ts
 
-A subset of the API model fields — the scripts run `formatModel()` which drops `canonical_slug`, `hugging_face_id`, `default_parameters`, `knowledge_cutoff`, and `links`.
+A subset of the raw API fields — the scripts run `formatModel()` which drops `canonical_slug`, `hugging_face_id`, `default_parameters`, `knowledge_cutoff`, and `links`. If you need those fields, call the API directly.
 
 ### compare-models.ts
 

--- a/skills/openrouter-models/SKILL.md
+++ b/skills/openrouter-models/SKILL.md
@@ -126,13 +126,26 @@ Returns for each provider:
 - **Provider-specific pricing** — some providers offer discounts
 - **Supported parameters** — varies by provider (some don't support all features)
 
-## Output Formats
+## API Response Shapes
 
-### list-models.ts / search-models.ts
+### GET /models
+
+`GET https://openrouter.ai/api/v1/models` returns `{ data: Model[] }`.
+
+**Query parameters** (all optional):
+
+| Parameter | Example | Effect |
+|---|---|---|
+| `category` | `?category=programming` | Server-side category filter |
+| `supported_parameters` | `?supported_parameters=tools` | Only models supporting this parameter |
+
+Each Model object has the shape shown below — these are the exact field names returned by the API:
 
 ```json
 {
   "id": "anthropic/claude-sonnet-4",
+  "canonical_slug": "anthropic/claude-sonnet-4-20250514",
+  "hugging_face_id": "null | string",
   "name": "Anthropic: Claude Sonnet 4",
   "description": "...",
   "created": 1747930371,
@@ -146,7 +159,8 @@ Returns for each provider:
     "tokenizer": "Claude",
     "modality": "text+image->text",
     "input_modalities": ["text", "image"],
-    "output_modalities": ["text"]
+    "output_modalities": ["text"],
+    "instruct_type": null
   },
   "top_provider": {
     "context_length": 1000000,
@@ -154,9 +168,76 @@ Returns for each provider:
     "is_moderated": false
   },
   "per_request_limits": null,
-  "supported_parameters": ["max_tokens", "temperature", "tools", "reasoning", "..."]
+  "supported_parameters": ["max_tokens", "temperature", "tools", "reasoning", "..."],
+  "default_parameters": {
+    "temperature": 1,
+    "top_p": 0.95,
+    "top_k": null,
+    "frequency_penalty": null,
+    "presence_penalty": null,
+    "repetition_penalty": null
+  },
+  "knowledge_cutoff": "2025-04-01",
+  "expiration_date": null,
+  "links": {
+    "details": "/api/v1/models/anthropic/claude-sonnet-4-20250514/endpoints"
+  }
 }
 ```
+
+- To check if a model supports a feature, use `model.supported_parameters` (e.g. `.includes("tools")`), or filter server-side with `?supported_parameters=tools`.
+- To check modalities, use `model.architecture.input_modalities` / `model.architecture.output_modalities`.
+- Pricing values are per-token in USD as strings — multiply by 1,000,000 for per-million-token pricing.
+- `knowledge_cutoff` and `expiration_date` are date strings or null.
+- `links.details` points to the per-provider endpoints API for that model.
+
+### GET /models/{id}/endpoints
+
+`GET https://openrouter.ai/api/v1/models/{canonical_slug}/endpoints` returns per-provider performance data. Requires `Authorization: Bearer <key>`.
+
+```json
+{
+  "data": {
+    "id": "anthropic/claude-sonnet-4",
+    "name": "Anthropic: Claude Sonnet 4",
+    "endpoints": [
+      {
+        "provider_name": "Anthropic",
+        "tag": "anthropic",
+        "status": 0,
+        "uptime_last_30m": 100.0,
+        "latency_last_30m": { "p50": 800, "p75": 1200, "p90": 2000, "p99": 5000 },
+        "throughput_last_30m": { "p50": 45, "p75": 55, "p90": 65, "p99": 90 },
+        "context_length": 1000000,
+        "max_completion_tokens": 64000,
+        "max_prompt_tokens": 950000,
+        "pricing": {
+          "prompt": "0.000003",
+          "completion": "0.000015",
+          "input_cache_read": "0.0000003",
+          "discount": 0
+        },
+        "quantization": "unknown",
+        "supports_implicit_caching": true,
+        "supported_parameters": ["max_tokens", "temperature", "tools", "..."]
+      }
+    ]
+  }
+}
+```
+
+- `status`: `0` = operational, non-zero = degraded
+- `uptime_last_30m`: raw float percentage (e.g. `99.5`)
+- `latency_last_30m` / `throughput_last_30m`: percentile objects with `p50`, `p75`, `p90`, `p99`
+- Pricing is per-token in USD as strings (same format as the models endpoint)
+
+## Script Output Formats
+
+The scripts below reformat the raw API data. When calling the API directly (e.g. via `fetch`), use the field names from the API Response Shapes section above.
+
+### list-models.ts / search-models.ts
+
+A subset of the API model fields — the scripts run `formatModel()` which drops `canonical_slug`, `hugging_face_id`, `default_parameters`, `knowledge_cutoff`, and `links`.
 
 ### compare-models.ts
 

--- a/skills/openrouter-models/SKILL.md
+++ b/skills/openrouter-models/SKILL.md
@@ -128,108 +128,27 @@ Returns for each provider:
 
 ## API Response Shapes
 
-### GET /models
+For full field reference, see:
+- [List models](https://openrouter.ai/docs/api/reference/list-models) — `GET /api/v1/models`
+- [Get a model](https://openrouter.ai/docs/api/reference/get-a-model) — `GET /api/v1/models/{id}`
+- [Get model endpoints](https://openrouter.ai/docs/api/reference/get-model-endpoints) — `GET /api/v1/models/{id}/endpoints`
 
-`GET https://openrouter.ai/api/v1/models` returns `{ data: Model[] }`.
-
-**Query parameters** (all optional):
+**Query parameters** for `GET /models` (all optional):
 
 | Parameter | Example | Effect |
 |---|---|---|
 | `category` | `?category=programming` | Server-side category filter |
 | `supported_parameters` | `?supported_parameters=tools` | Only models supporting this parameter |
 
-Each Model object has the shape shown below — these are the exact field names returned by the API:
-
-```json
-{
-  "id": "anthropic/claude-sonnet-4",
-  "canonical_slug": "anthropic/claude-sonnet-4-20250514",
-  "hugging_face_id": "null | string",
-  "name": "Anthropic: Claude Sonnet 4",
-  "description": "...",
-  "created": 1747930371,
-  "context_length": 1000000,
-  "pricing": {
-    "prompt": "0.000003",
-    "completion": "0.000015",
-    "input_cache_read": "0.0000003"
-  },
-  "architecture": {
-    "tokenizer": "Claude",
-    "modality": "text+image->text",
-    "input_modalities": ["text", "image"],
-    "output_modalities": ["text"],
-    "instruct_type": null
-  },
-  "top_provider": {
-    "context_length": 1000000,
-    "max_completion_tokens": 64000,
-    "is_moderated": false
-  },
-  "per_request_limits": null,
-  "supported_parameters": ["max_tokens", "temperature", "tools", "reasoning", "..."],
-  "default_parameters": {
-    "temperature": 1,
-    "top_p": 0.95,
-    "top_k": null,
-    "frequency_penalty": null,
-    "presence_penalty": null,
-    "repetition_penalty": null
-  },
-  "knowledge_cutoff": "2025-04-01",
-  "expiration_date": null,
-  "links": {
-    "details": "/api/v1/models/anthropic/claude-sonnet-4-20250514/endpoints"
-  }
-}
-```
+**Tips for working with the response:**
 
 - To check if a model supports a feature, use `model.supported_parameters` (e.g. `.includes("tools")`), or filter server-side with `?supported_parameters=tools`.
 - To check modalities, use `model.architecture.input_modalities` / `model.architecture.output_modalities`.
 - Pricing values are per-token in USD as strings — multiply by 1,000,000 for per-million-token pricing.
 - `knowledge_cutoff` and `expiration_date` are date strings or null.
 - `links.details` points to the per-provider endpoints API for that model.
-
-### GET /models/{id}/endpoints
-
-`GET https://openrouter.ai/api/v1/models/{canonical_slug}/endpoints` returns per-provider performance data. Requires `Authorization: Bearer <key>`.
-
-```json
-{
-  "data": {
-    "id": "anthropic/claude-sonnet-4",
-    "name": "Anthropic: Claude Sonnet 4",
-    "endpoints": [
-      {
-        "provider_name": "Anthropic",
-        "tag": "anthropic",
-        "status": 0,
-        "uptime_last_30m": 100.0,
-        "latency_last_30m": { "p50": 800, "p75": 1200, "p90": 2000, "p99": 5000 },
-        "throughput_last_30m": { "p50": 45, "p75": 55, "p90": 65, "p99": 90 },
-        "context_length": 1000000,
-        "max_completion_tokens": 64000,
-        "max_prompt_tokens": 950000,
-        "pricing": {
-          "prompt": "0.000003",
-          "completion": "0.000015",
-          "input_cache_read": "0.0000003",
-          "discount": 0
-        },
-        "quantization": "unknown",
-        "supports_implicit_caching": true,
-        "supported_parameters": ["max_tokens", "temperature", "tools", "..."]
-      }
-    ]
-  }
-}
-```
-
-- `status`: `0` = operational, non-zero = degraded
-- `uptime_last_30m`: raw float percentage (e.g. `99.5`)
-- `latency_last_30m` / `throughput_last_30m`: percentile objects with `p50`, `p75`, `p90`, `p99`
-- Pricing is per-token in USD as strings (same format as the models endpoint)
+- Endpoint `status`: `0` = operational, non-zero = degraded.
+- Endpoint `latency_last_30m` / `throughput_last_30m`: percentile objects with `p50`, `p75`, `p90`, `p99`.
 
 ## Script Output Formats
 

--- a/skills/openrouter-models/SKILL.md
+++ b/skills/openrouter-models/SKILL.md
@@ -149,7 +149,7 @@ For full field reference, see the [Models reference](https://openrouter.ai/docs/
 
 ## Script Output Formats
 
-The scripts below reformat the raw API data. When calling the API directly (e.g. via `fetch`), refer to the [Models reference](https://openrouter.ai/docs/guides/overview/models) for field names.
+The scripts below reformat the raw API data. When calling the API directly (e.g. via `fetch`), refer to the [OpenAPI spec](https://openrouter.ai/openapi.json) for field names.
 
 ### list-models.ts / search-models.ts
 

--- a/skills/openrouter-oauth/SKILL.md
+++ b/skills/openrouter-oauth/SKILL.md
@@ -217,6 +217,6 @@ For the type-safe SDK approach (`callModel`, streaming, tool use), see the `open
 ## Resources
 
 - [OAuth PKCE guide](https://openrouter.ai/docs/guides/overview/auth/oauth) — full parameter reference and key management
-- [Authentication API reference](https://openrouter.ai/docs/api/reference/authentication) — `/auth/key` and `/credits` response shapes
+- [Authentication guide](https://openrouter.ai/docs/api/reference/authentication) — API key usage and Bearer token setup
 - [Live demo](https://openrouterteam.github.io/sign-in-with-openrouter/) — interactive button playground
 - [OpenRouter TypeScript SDK](https://openrouter.ai/docs/sdks/typescript/overview) — `callModel` pattern for completions and streaming

--- a/skills/openrouter-oauth/SKILL.md
+++ b/skills/openrouter-oauth/SKILL.md
@@ -194,40 +194,6 @@ For dark mode support, add dark variants: swap light backgrounds to dark (`dark:
 
 ---
 
-## API Response Shapes
-
-These are the exact field names returned by the OpenRouter API when querying account information:
-
-`GET https://openrouter.ai/api/v1/auth/key` — returns current API key metadata:
-
-```json
-{
-  "data": {
-    "label": "My API Key",
-    "usage": 42.50,
-    "limit": 100,
-    "is_free_tier": false,
-    "rate_limit": {
-      "requests": 200,
-      "interval": "10s"
-    }
-  }
-}
-```
-
-`GET https://openrouter.ai/api/v1/credits` — returns credit balance:
-
-```json
-{
-  "data": {
-    "total_credits": 100.00,
-    "total_usage": 42.50
-  }
-}
-```
-
----
-
 ## Using the API Key
 
 ```typescript
@@ -251,5 +217,6 @@ For the type-safe SDK approach (`callModel`, streaming, tool use), see the `open
 ## Resources
 
 - [OAuth PKCE guide](https://openrouter.ai/docs/guides/overview/auth/oauth) — full parameter reference and key management
+- [Authentication API reference](https://openrouter.ai/docs/api/reference/authentication) — `/auth/key` and `/credits` response shapes
 - [Live demo](https://openrouterteam.github.io/sign-in-with-openrouter/) — interactive button playground
 - [OpenRouter TypeScript SDK](https://openrouter.ai/docs/sdks/typescript/overview) — `callModel` pattern for completions and streaming

--- a/skills/openrouter-oauth/SKILL.md
+++ b/skills/openrouter-oauth/SKILL.md
@@ -194,10 +194,44 @@ For dark mode support, add dark variants: swap light backgrounds to dark (`dark:
 
 ---
 
+## API Response Shapes
+
+These are the exact field names returned by the OpenRouter API when querying account information:
+
+`GET https://openrouter.ai/api/v1/auth/key` — returns current API key metadata:
+
+```json
+{
+  "data": {
+    "label": "My API Key",
+    "usage": 42.50,
+    "limit": 100,
+    "is_free_tier": false,
+    "rate_limit": {
+      "requests": 200,
+      "interval": "10s"
+    }
+  }
+}
+```
+
+`GET https://openrouter.ai/api/v1/credits` — returns credit balance:
+
+```json
+{
+  "data": {
+    "total_credits": 100.00,
+    "total_usage": 42.50
+  }
+}
+```
+
+---
+
 ## Using the API Key
 
 ```typescript
-const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+const response = await fetch("https://openrouter.ai/api/v1/responses", {
   method: "POST",
   headers: {
     Authorization: `Bearer ${apiKey}`,
@@ -205,7 +239,7 @@ const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
   },
   body: JSON.stringify({
     model: "openai/gpt-4o-mini",
-    messages: [{ role: "user", content: "Hello!" }],
+    input: [{ role: "user", content: "Hello!" }],
   }),
 });
 ```

--- a/skills/openrouter-oauth/SKILL.md
+++ b/skills/openrouter-oauth/SKILL.md
@@ -205,7 +205,7 @@ const response = await fetch("https://openrouter.ai/api/v1/responses", {
   },
   body: JSON.stringify({
     model: "openai/gpt-4o-mini",
-    input: [{ role: "user", content: "Hello!" }],
+    input: [{ type: "message", role: "user", content: "Hello!" }],
   }),
 });
 ```


### PR DESCRIPTION
This pull request updates documentation for the OpenRouter skills, focusing on clarifying API response formats, improving usage examples, and adding helpful references. The main changes enhance developer understanding of API shapes, usage patterns, and available documentation resources.

**API Response and Output Format Documentation:**

- Added a new "API Response Shapes" section to `skills/openrouter-images/SKILL.md`, detailing the structure of image generation responses, including the `image_generation_call` output item type and its usage alongside standard message outputs.
- Expanded the "API Response Shapes" section in `skills/openrouter-models/SKILL.md` to explain the structure and fields returned by the models API, provide tips for working with the response, and clarify the differences between raw API fields and script output formats.

**Code Example and Usage Improvements:**

- Updated the example API call in `skills/openrouter-oauth/SKILL.md` to use the correct endpoint (`/api/v1/responses`) and payload shape (using `input` instead of `messages`) for chat completions, ensuring consistency with the latest API.

**Documentation Resource Additions:**

- Added a link to the API authentication guide in the resources section of `skills/openrouter-oauth/SKILL.md` for easier access to API key and Bearer token setup documentation.