### PR TITLE
feat(create-headless-agent): prompt for agent name, add bun link step

### DIFF
--- a/skills/create-headless-agent/README.md
+++ b/skills/create-headless-agent/README.md
@@ -136,24 +136,34 @@ A complete working agent with all defaults is in [`sample/`](sample/).
 ```bash
 cd sample
 bun install
-OPENROUTER_API_KEY=your-key bun start
+export OPENROUTER_API_KEY=your-key
+
+# Register the agent as a global CLI (one-time setup)
+bun link
+
+# Now invoke it by name from anywhere
+my-agent "List all TypeScript files"
 ```
 
-Usage:
+The skill asks for the agent's name during generation and wires it as the `bin` entry in `package.json` — so `bun link` makes it a globally-invokable command with that name.
+
+Other usage:
 
 ```bash
-# From argument
-bun run src/cli.ts "List all TypeScript files"
-
 # From stdin
-echo "Summarize README.md" | bun run src/cli.ts
+echo "Summarize README.md" | my-agent
 
 # JSON event stream
-bun run src/cli.ts --json "Search for TODO comments"
+my-agent --json "Search for TODO comments"
 
 # Override model
-bun run src/cli.ts -m anthropic/claude-sonnet-4.6 -p "Review this code"
+my-agent -m anthropic/claude-sonnet-4.6 -p "Review this code"
+
+# Without linking (run directly via Bun)
+bun run src/cli.ts "List all TypeScript files"
 ```
+
+To unregister later: `bun unlink` inside the project directory.
 
 ## Highlighted features
 

--- a/skills/create-headless-agent/SKILL.md
+++ b/skills/create-headless-agent/SKILL.md
@@ -91,10 +91,17 @@ Server tools go in the `tools` array alongside user-defined tools. No client cod
 
 ## Generation Workflow
 
-After getting checklist selections, follow this workflow:
+Before generating, **ask the user what to name their agent**. This name is used as:
+- the `"name"` field in `package.json`
+- the `"bin"` command (so `bun link` makes it a globally-invokable CLI)
+- the project directory name (if creating a new directory)
+
+Suggested question: *"What would you like to call your agent? (short kebab-case, e.g. `research-bot` or `docs-helper`)"*. Validate the answer is a valid npm package name (lowercase, kebab-case, no spaces). Default to `my-agent` if the user has no preference. Use the chosen name everywhere the workflow below shows `<agent-name>`.
+
+After getting the name and checklist selections, follow this workflow:
 
 ```
-- [ ] Generate package.json (bun init, add deps)
+- [ ] Generate package.json with name=<agent-name> and bin={"<agent-name>": "src/cli.ts"}
 - [ ] Generate tsconfig.json (Bun-native)
 - [ ] Generate src/config.ts
 - [ ] Generate src/tools/index.ts wiring selected tools
@@ -102,14 +109,27 @@ After getting checklist selections, follow this workflow:
 - [ ] Generate src/agent.ts (core runner)
 - [ ] If Session Persistence ON: generate src/session.ts (spec in references/modules.md)
 - [ ] Generate selected modules (specs in references/modules.md)
-- [ ] Generate src/cli.ts entry point (spec in references/entry-points.md)
+- [ ] Generate src/cli.ts entry point with shebang `#!/usr/bin/env bun` (spec in references/entry-points.md)
 - [ ] If HTTP server selected: generate src/server.ts (spec in references/entry-points.md)
 - [ ] If MCP server selected: generate src/mcp-server.ts (spec in references/entry-points.md)
 - [ ] Generate .env.example
 - [ ] Generate test/agent.test.ts
-- [ ] Verify: run bunx tsc --noEmit
+- [ ] Run `bun install` to fetch dependencies
+- [ ] Verify: run `bunx tsc --noEmit`
+- [ ] Run `bun link` inside the project to register <agent-name> globally
+- [ ] Tell the user they can now invoke their agent from anywhere with `<agent-name> "<prompt>"`
 - [ ] Optional: run `npx skills-ref validate .` to check SKILL.md frontmatter (if installed)
 ```
+
+After generation, the user can run their agent from any directory:
+
+```bash
+<agent-name> "What's in this repo?"
+echo "Summarize README.md" | <agent-name>
+<agent-name> --json "List all TODOs" | jq .
+```
+
+To later rename the agent, update the `name` and `bin` keys in `package.json`, then run `bun unlink && bun link`.
 
 ---
 
@@ -160,7 +180,7 @@ These files are always generated. The agent adapts them based on checklist selec
 
 ### package.json
 
-Initialize the project and install dependencies:
+Initialize the project and install dependencies. Replace `<agent-name>` with the name the user chose:
 
 ```bash
 bun init -y
@@ -169,8 +189,11 @@ bun init -y
 
 ```json
 {
-  "name": "my-agent",
+  "name": "<agent-name>",
   "type": "module",
+  "bin": {
+    "<agent-name>": "src/cli.ts"
+  },
   "scripts": {
     "start": "bun run src/cli.ts",
     "dev": "bun --watch src/cli.ts",
@@ -187,6 +210,8 @@ bun init -y
   }
 }
 ```
+
+The `bin` entry is what makes the agent invokable by name after `bun link`. The target (`src/cli.ts`) must have a `#!/usr/bin/env bun` shebang on the first line.
 
 ### tsconfig.json
 

--- a/skills/create-headless-agent/SKILL.md
+++ b/skills/create-headless-agent/SKILL.md
@@ -117,6 +117,8 @@ After getting the name and checklist selections, follow this workflow:
 - [ ] Run `bun install` to fetch dependencies
 - [ ] Verify: run `bunx tsc --noEmit`
 - [ ] Run `bun link` inside the project to register <agent-name> globally
+- [ ] Verify the command is on PATH: `command -v <agent-name>` should print a path. If it fails, tell the user to add Bun's bin dir to their shell rc:
+      `export PATH="$HOME/.bun/bin:$PATH"` (for bash/zsh). `bun link` silently succeeds even when `~/.bun/bin` isn't on PATH, so without this check the user will be told the agent is globally available but `command not found` will greet them.
 - [ ] Tell the user they can now invoke their agent from anywhere with `<agent-name> "<prompt>"`
 - [ ] Optional: run `npx skills-ref validate .` to check SKILL.md frontmatter (if installed)
 ```

--- a/skills/create-headless-agent/references/entry-points.md
+++ b/skills/create-headless-agent/references/entry-points.md
@@ -16,7 +16,10 @@ The primary entry point. Accepts a prompt via `--prompt`, positional argument, o
 
 ### src/cli.ts
 
+The `#!/usr/bin/env bun` shebang on line 1 is required so the OS can execute the file directly when it's invoked via the `bin` symlink created by `bun link`. Without it, the linked binary fails with "Exec format error".
+
 ```typescript
+#!/usr/bin/env bun
 import { parseArgs } from 'util';
 import { readFileSync } from 'fs';
 import { loadConfig } from './config.js';

--- a/skills/create-headless-agent/sample/package.json
+++ b/skills/create-headless-agent/sample/package.json
@@ -1,6 +1,9 @@
 {
   "name": "my-agent",
   "type": "module",
+  "bin": {
+    "my-agent": "src/cli.ts"
+  },
   "scripts": {
     "start": "bun run src/cli.ts",
     "dev": "bun --watch src/cli.ts",

--- a/skills/create-headless-agent/sample/src/cli.ts
+++ b/skills/create-headless-agent/sample/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 import { parseArgs } from 'util';
 import { readFileSync } from 'fs';
 import { loadConfig } from './config.js';


### PR DESCRIPTION
## Summary
- The skill now asks the user for an agent name at the start of generation and uses it as both the npm `name` and the `bin` command
- After generation, `bun link` registers the agent as a global CLI so users can invoke it from any directory (e.g. `my-agent \"what's in this repo?\"`)
- Sample demonstrates the feature end-to-end (verified: `bun link` → `my-agent \"...\"` from /tmp hit the OpenRouter API successfully)

## Changes
- `SKILL.md` — new pre-generation step to collect `<agent-name>`; `package.json` template now has a `bin` entry; generation workflow includes `bun install` and `bun link`; note on renaming with `bun unlink && bun link`
- `sample/package.json` — add `bin: { "my-agent": "src/cli.ts" }`
- `sample/src/cli.ts` — add `#!/usr/bin/env bun` shebang (required for linked executables); file mode changed to 100755
- `README.md` — Sample section shows the `bun link` → global-CLI workflow

## Test plan
- [x] `bun install` in sample/
- [x] `bunx tsc --noEmit` passes
- [x] `bun test` — 18/18 pass
- [x] `bun link` registers `my-agent` globally
- [x] `cd /tmp && my-agent "..."` runs the linked CLI against the real API
- [x] `bun unlink` cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)