### PR TITLE
Context-management patterns from Pi/OpenClaw/Claude Code

### DIFF
--- a/skills/create-agent-tui/SKILL.md
+++ b/skills/create-agent-tui/SKILL.md
@@ -158,13 +158,17 @@ import { tool } from '@openrouter/agent/tool';
 import { z } from 'zod';
 import { readFile, stat } from 'fs/promises';
 
+const DEFAULT_LINE_LIMIT = 2000;
+const MAX_LINE_CHARS = 2000;
+
 export const fileReadTool = tool({
   name: 'file_read',
-  description: 'Read the contents of a file at the given path',
+  description:
+    'Read the contents of a file. Output is capped at 2000 lines by default (use offset/limit to paginate) and any line longer than 2000 characters is truncated. When the response is truncated, the hint field tells you how to continue.',
   inputSchema: z.object({
     path: z.string().describe('Absolute path to the file'),
     offset: z.number().optional().describe('Start reading from this line (1-indexed)'),
-    limit: z.number().optional().describe('Maximum number of lines to return'),
+    limit: z.number().optional().describe(`Maximum lines to return (default ${DEFAULT_LINE_LIMIT})`),
   }),
   execute: async ({ path, offset, limit }) => {
     try {
@@ -172,13 +176,27 @@ export const fileReadTool = tool({
       const lines = content.split('\n');
 
       const start = offset ? offset - 1 : 0;
-      const end = limit ? start + limit : lines.length;
-      const slice = lines.slice(start, end);
+      const end = Math.min(start + (limit ?? DEFAULT_LINE_LIMIT), lines.length);
+      let longLines = 0;
+      const slice = lines.slice(start, end).map((line) => {
+        if (line.length <= MAX_LINE_CHARS) return line;
+        longLines++;
+        return line.slice(0, MAX_LINE_CHARS) + `… [line truncated, ${line.length - MAX_LINE_CHARS} chars dropped]`;
+      });
+      const tailTruncated = end < lines.length;
+      const truncated = tailTruncated || longLines > 0;
+      const hintParts: string[] = [`Showing lines ${start + 1}-${end} of ${lines.length}.`];
+      if (tailTruncated) hintParts.push(`Use offset=${end + 1} to continue.`);
+      if (longLines > 0) hintParts.push(`${longLines} line(s) exceeded ${MAX_LINE_CHARS} chars and were per-line truncated; use grep to fetch content from those lines.`);
 
       return {
         content: slice.join('\n'),
         totalLines: lines.length,
-        ...(end < lines.length && { truncated: true, nextOffset: end + 1 }),
+        ...(truncated && {
+          truncated: true,
+          ...(tailTruncated && { nextOffset: end + 1 }),
+          hint: hintParts.join(' '),
+        }),
       };
     } catch (err: any) {
       if (err.code === 'ENOENT') return { error: `File not found: ${path}` };

--- a/skills/create-agent-tui/SKILL.md
+++ b/skills/create-agent-tui/SKILL.md
@@ -383,7 +383,13 @@ export async function runAgent(
   });
 
   if (options?.onEvent) {
-    let lastTextLen = 0;
+    // Track text length PER message item by id. A multi-step agent emits
+    // multiple OutputMessage items over the course of a single run (one per
+    // assistant turn between tool calls), and each one grows from 0 to its
+    // final length. A single global cursor breaks on the second message:
+    // when its length is smaller than the cursor from the first, the slice
+    // cuts mid-string and drops the start of the new message's text.
+    const textByItem = new Map<string, number>();
     const callNames = new Map<string, string>();
 
     for await (const item of result.getItemsStream()) {
@@ -393,9 +399,10 @@ export async function runAgent(
           ?.filter((c): c is { type: 'output_text'; text: string } => 'text' in c)
           .map((c) => c.text)
           .join('') ?? '';
-        if (text.length > lastTextLen) {
-          options.onEvent({ type: 'text', delta: text.slice(lastTextLen) });
-          lastTextLen = text.length;
+        const prev = textByItem.get(item.id) ?? 0;
+        if (text.length > prev) {
+          options.onEvent({ type: 'text', delta: text.slice(prev) });
+          textByItem.set(item.id, text.length);
         }
       } else if (item.type === 'function_call') {
         callNames.set(item.callId, item.name);

--- a/skills/create-agent-tui/references/modules.md
+++ b/skills/create-agent-tui/references/modules.md
@@ -126,6 +126,43 @@ const DEFAULTS: CompactionConfig = {
   model: 'openai/gpt-4.1-mini',
 };
 
+/**
+ * Walk the initial cut point forward until we land somewhere that doesn't
+ * split a tool turn. A tool turn looks like:
+ *
+ *   assistant (with tool_calls) → tool (result) × N → assistant (text)
+ *
+ * If the boundary falls between the assistant-with-calls and its tool
+ * results, the summarized half would end with an unresolved call and the
+ * kept half would start with orphaned results — the model sees a
+ * half-finished turn and gets confused. Pi, OpenClaw, and Claude Code all
+ * enforce this invariant in their compaction paths.
+ *
+ * Safe cut points are before a user message or before a plain assistant
+ * message with no pending tool_calls.
+ */
+function findSafeBoundary(messages: Message[], cut: number): number {
+  while (cut < messages.length) {
+    const msg = messages[cut];
+
+    // Orphaned tool result at the boundary — step past it so the pair
+    // stays together on the summarized side.
+    if (msg.role === 'tool') { cut++; continue; }
+
+    // Assistant with unresolved tool_calls — step past it and any
+    // trailing tool results from the same turn.
+    const toolCalls = (msg as { tool_calls?: unknown[] }).tool_calls;
+    if (msg.role === 'assistant' && Array.isArray(toolCalls) && toolCalls.length > 0) {
+      cut++;
+      while (cut < messages.length && messages[cut].role === 'tool') cut++;
+      continue;
+    }
+
+    break;
+  }
+  return cut;
+}
+
 export async function compactMessages(
   client: OpenRouter,
   messages: Message[],
@@ -135,8 +172,16 @@ export async function compactMessages(
 
   if (messages.length <= opts.threshold) return messages;
 
-  const toSummarize = messages.slice(0, -opts.keepRecent);
-  const toKeep = messages.slice(-opts.keepRecent);
+  const idealCut = messages.length - opts.keepRecent;
+  const safeCut = findSafeBoundary(messages, idealCut);
+
+  // If the boundary walked all the way to the end (rare: every remaining
+  // message is part of one giant tool turn), give up on compacting rather
+  // than summarize everything and leave nothing behind.
+  if (safeCut >= messages.length) return messages;
+
+  const toSummarize = messages.slice(0, safeCut);
+  const toKeep = messages.slice(safeCut);
 
   const summaryResult = client.callModel({
     model: opts.model,

--- a/skills/create-agent-tui/references/tool-display.md
+++ b/skills/create-agent-tui/references/tool-display.md
@@ -119,6 +119,12 @@ export class TuiRenderer {
   }
 
   private renderText(delta: string): void {
+    // Flush any pending tool-call buffers BEFORE streaming text. Grouped
+    // mode queues tool calls until category change or endTurn, so without
+    // this the block would appear delayed — sometimes at the very end of
+    // the response — instead of in the spot where the model actually
+    // called the tool.
+    this.flushGrouped();
     this.flushMinimal();
     this.streaming = true;
     process.stdout.write(delta);

--- a/skills/create-agent-tui/references/tools.md
+++ b/skills/create-agent-tui/references/tools.md
@@ -17,6 +17,9 @@ Read file contents with optional offset/limit. Full example in SKILL.md.
 
 - **inputSchema**: `path` (string), `offset?` (number, 1-indexed line), `limit?` (number, max lines)
 - **Behavior**: Read file as UTF-8, split lines, slice by offset/limit, return content + totalLines + truncated flag
+- **Default line cap**: When `limit` is omitted, return at most 2000 lines. The harness caps *even if the model didn't ask*, so the model never accidentally floods context with a 50k-line file. Pi and Claude Code both use this pattern (Pi: 2000 lines/50KB, Claude Code: 2000 lines + 256KB byte gate).
+- **Per-line truncation**: Truncate any single line longer than 2000 characters with a `… [line truncated, N chars dropped]` suffix. This dodges minified bundles and JSON dumps that would otherwise consume a whole output budget in one line. Count how many lines were affected so the model sees that fact in the hint — otherwise a 500-line file with one 10MB minified line would silently return incomplete content with `truncated: false`.
+- **Continuation hint**: When *anything* was truncated (tail OR any per-line truncation), set `truncated: true` and include a `hint` string explaining both forms of truncation. Example: `"Showing lines 1-2000 of 50000. Use offset=2001 to continue. 3 line(s) exceeded 2000 chars and were per-line truncated; use grep to fetch content from those lines."` The hint lives inside the returned JSON so the model actually sees it — a `truncated: true` boolean alone is easy to miss. `nextOffset` is only set when the *tail* was truncated, since line-based pagination can't recover per-line truncated content.
 - **Image detection**: Check extension for jpg/png/gif/webp — if image, read as base64 and return `{ type: 'image', data, mimeType }`
 - **Read-only**
 

--- a/skills/create-agent-tui/sample/src/agent.ts
+++ b/skills/create-agent-tui/sample/src/agent.ts
@@ -28,7 +28,13 @@ export async function runAgent(
   });
 
   if (options?.onEvent) {
-    let lastTextLen = 0;
+    // Track text length PER message item by id. A multi-step agent emits
+    // multiple OutputMessage items over the course of a single run (one per
+    // assistant turn between tool calls), and each one grows from 0 to its
+    // final length. A single global cursor breaks on the second message:
+    // when its length is smaller than the cursor from the first, the slice
+    // cuts mid-string and drops the start of the new message's text.
+    const textByItem = new Map<string, number>();
     const callNames = new Map<string, string>();
 
     for await (const item of result.getItemsStream()) {
@@ -38,9 +44,10 @@ export async function runAgent(
           ?.filter((c): c is { type: 'output_text'; text: string } => 'text' in c)
           .map((c) => c.text)
           .join('') ?? '';
-        if (text.length > lastTextLen) {
-          options.onEvent({ type: 'text', delta: text.slice(lastTextLen) });
-          lastTextLen = text.length;
+        const prev = textByItem.get(item.id) ?? 0;
+        if (text.length > prev) {
+          options.onEvent({ type: 'text', delta: text.slice(prev) });
+          textByItem.set(item.id, text.length);
         }
       } else if (item.type === 'function_call') {
         callNames.set(item.callId, item.name);

--- a/skills/create-agent-tui/sample/src/renderer.ts
+++ b/skills/create-agent-tui/sample/src/renderer.ts
@@ -92,6 +92,12 @@ export class TuiRenderer {
   }
 
   private renderText(delta: string): void {
+    // Flush any pending tool-call buffers BEFORE streaming text. Grouped
+    // mode queues tool calls until category change or endTurn, so without
+    // this the block would appear delayed — sometimes at the very end of
+    // the response — instead of in the spot where the model actually
+    // called the tool.
+    this.flushGrouped();
     this.flushMinimal();
     this.streaming = true;
     this.lineBuf += delta;

--- a/skills/create-agent-tui/sample/src/tools/file-read.ts
+++ b/skills/create-agent-tui/sample/src/tools/file-read.ts
@@ -2,13 +2,17 @@ import { tool } from '@openrouter/agent/tool';
 import { z } from 'zod';
 import { readFile } from 'fs/promises';
 
+const DEFAULT_LINE_LIMIT = 2000;
+const MAX_LINE_CHARS = 2000;
+
 export const fileReadTool = tool({
   name: 'file_read',
-  description: 'Read the contents of a file at the given path',
+  description:
+    'Read the contents of a file. Output is capped at 2000 lines by default (use offset/limit to paginate) and any line longer than 2000 characters is truncated. When the response is truncated, the hint field tells you how to continue.',
   inputSchema: z.object({
     path: z.string().describe('Absolute path to the file'),
     offset: z.number().optional().describe('Start reading from this line (1-indexed)'),
-    limit: z.number().optional().describe('Maximum number of lines to return'),
+    limit: z.number().optional().describe(`Maximum lines to return (default ${DEFAULT_LINE_LIMIT})`),
   }),
   execute: async ({ path, offset, limit }) => {
     try {
@@ -16,13 +20,27 @@ export const fileReadTool = tool({
       const lines = content.split('\n');
 
       const start = offset ? offset - 1 : 0;
-      const end = limit ? start + limit : lines.length;
-      const slice = lines.slice(start, end);
+      const end = Math.min(start + (limit ?? DEFAULT_LINE_LIMIT), lines.length);
+      let longLines = 0;
+      const slice = lines.slice(start, end).map((line) => {
+        if (line.length <= MAX_LINE_CHARS) return line;
+        longLines++;
+        return line.slice(0, MAX_LINE_CHARS) + `… [line truncated, ${line.length - MAX_LINE_CHARS} chars dropped]`;
+      });
+      const tailTruncated = end < lines.length;
+      const truncated = tailTruncated || longLines > 0;
+      const hintParts: string[] = [`Showing lines ${start + 1}-${end} of ${lines.length}.`];
+      if (tailTruncated) hintParts.push(`Use offset=${end + 1} to continue.`);
+      if (longLines > 0) hintParts.push(`${longLines} line(s) exceeded ${MAX_LINE_CHARS} chars and were per-line truncated; use grep to fetch content from those lines.`);
 
       return {
         content: slice.join('\n'),
         totalLines: lines.length,
-        ...(end < lines.length && { truncated: true, nextOffset: end + 1 }),
+        ...(truncated && {
+          truncated: true,
+          ...(tailTruncated && { nextOffset: end + 1 }),
+          hint: hintParts.join(' '),
+        }),
       };
     } catch (err: any) {
       if (err.code === 'ENOENT') return { error: `File not found: ${path}` };

--- a/skills/create-headless-agent/SKILL.md
+++ b/skills/create-headless-agent/SKILL.md
@@ -73,6 +73,7 @@ Server tools go in the `tools` array alongside user-defined tools. No client cod
 | Session Persistence | ON | JSONL conversation log, `--no-session` to disable |
 | Retry with Backoff | ON | Built into agent.ts |
 | Context Compaction | OFF | Summarize when context is long |
+| Tool Result Offload | OFF | Persist oversized tool outputs to disk, keep preview in context |
 | System Prompt Composition | OFF | Dynamic instructions from context files |
 | Tool Approval Flow | OFF | Programmatic approve/reject |
 | Structured Event Logging | OFF | JSON events to stderr |
@@ -143,25 +144,43 @@ All user-defined tools follow this pattern using `@openrouter/agent/tool`. Here 
 import { tool } from '@openrouter/agent/tool';
 import { z } from 'zod';
 
+const DEFAULT_LINE_LIMIT = 2000;
+const MAX_LINE_CHARS = 2000;
+
 export const fileReadTool = tool({
   name: 'file_read',
-  description: 'Read the contents of a file at the given path',
+  description:
+    'Read the contents of a file. Output is capped at 2000 lines by default (use offset/limit to paginate) and any line longer than 2000 characters is truncated. When the response is truncated, the hint field tells you how to continue.',
   inputSchema: z.object({
     path: z.string().describe('Absolute path to the file'),
     offset: z.number().optional().describe('Start reading from this line (1-indexed)'),
-    limit: z.number().optional().describe('Maximum number of lines to return'),
+    limit: z.number().optional().describe(`Maximum lines to return (default ${DEFAULT_LINE_LIMIT})`),
   }),
   execute: async ({ path, offset, limit }) => {
     try {
       const content = await Bun.file(path).text();
       const lines = content.split('\n');
       const start = offset ? offset - 1 : 0;
-      const end = limit ? start + limit : lines.length;
-      const slice = lines.slice(start, end);
+      const end = Math.min(start + (limit ?? DEFAULT_LINE_LIMIT), lines.length);
+      let longLines = 0;
+      const slice = lines.slice(start, end).map((line) => {
+        if (line.length <= MAX_LINE_CHARS) return line;
+        longLines++;
+        return line.slice(0, MAX_LINE_CHARS) + `… [line truncated, ${line.length - MAX_LINE_CHARS} chars dropped]`;
+      });
+      const tailTruncated = end < lines.length;
+      const truncated = tailTruncated || longLines > 0;
+      const hintParts: string[] = [`Showing lines ${start + 1}-${end} of ${lines.length}.`];
+      if (tailTruncated) hintParts.push(`Use offset=${end + 1} to continue.`);
+      if (longLines > 0) hintParts.push(`${longLines} line(s) exceeded ${MAX_LINE_CHARS} chars and were per-line truncated; use grep to fetch content from those lines.`);
       return {
         content: slice.join('\n'),
         totalLines: lines.length,
-        ...(end < lines.length && { truncated: true, nextOffset: end + 1 }),
+        ...(truncated && {
+          truncated: true,
+          ...(tailTruncated && { nextOffset: end + 1 }),
+          hint: hintParts.join(' '),
+        }),
       };
     } catch (err: any) {
       if (err.code === 'ENOENT') return { error: `File not found: ${path}` };

--- a/skills/create-headless-agent/references/modules.md
+++ b/skills/create-headless-agent/references/modules.md
@@ -6,6 +6,7 @@ Optional architectural modules that extend the core headless agent. Each section
 
 - [Session Persistence](#session-persistence) -- JSONL conversation log (DEFAULT ON)
 - [Context Compaction](#context-compaction) -- summarize older messages
+- [Tool Result Offload](#tool-result-offload) -- persist oversized tool outputs to disk, keep preview in context
 - [System Prompt Composition](#system-prompt-composition) -- dynamic instructions from context files
 - [Tool Approval](#tool-approval) -- programmatic approval for headless execution
 - [Persistent State (StateAccessor)](#persistent-state-stateaccessor) -- resumable agent state for approvals, interruptions, multi-turn
@@ -143,6 +144,43 @@ const DEFAULTS: CompactionConfig = {
   model: 'openai/gpt-4.1-mini',
 };
 
+/**
+ * Walk the initial cut point forward until we land somewhere that doesn't
+ * split a tool turn. A tool turn looks like:
+ *
+ *   assistant (with tool_calls) → tool (result) × N → assistant (text)
+ *
+ * If the boundary falls between the assistant-with-calls and its tool
+ * results, the summarized half would end with an unresolved call and the
+ * kept half would start with orphaned results — the model sees a
+ * half-finished turn and gets confused. Pi, OpenClaw, and Claude Code all
+ * enforce this invariant in their compaction paths.
+ *
+ * Safe cut points are before a user message or before a plain assistant
+ * message with no pending tool_calls.
+ */
+function findSafeBoundary(messages: Message[], cut: number): number {
+  while (cut < messages.length) {
+    const msg = messages[cut];
+
+    // Orphaned tool result at the boundary — step past it so the pair
+    // stays together on the summarized side.
+    if (msg.role === 'tool') { cut++; continue; }
+
+    // Assistant with unresolved tool_calls — step past it and any
+    // trailing tool results from the same turn.
+    const toolCalls = (msg as { tool_calls?: unknown[] }).tool_calls;
+    if (msg.role === 'assistant' && Array.isArray(toolCalls) && toolCalls.length > 0) {
+      cut++;
+      while (cut < messages.length && messages[cut].role === 'tool') cut++;
+      continue;
+    }
+
+    break;
+  }
+  return cut;
+}
+
 export async function compactMessages(
   client: OpenRouter,
   messages: Message[],
@@ -152,8 +190,16 @@ export async function compactMessages(
 
   if (messages.length <= opts.threshold) return messages;
 
-  const toSummarize = messages.slice(0, -opts.keepRecent);
-  const toKeep = messages.slice(-opts.keepRecent);
+  const idealCut = messages.length - opts.keepRecent;
+  const safeCut = findSafeBoundary(messages, idealCut);
+
+  // If the boundary walked all the way to the end (rare: every remaining
+  // message is part of one giant tool turn), give up on compacting rather
+  // than summarize everything and leave nothing behind.
+  if (safeCut >= messages.length) return messages;
+
+  const toSummarize = messages.slice(0, safeCut);
+  const toKeep = messages.slice(safeCut);
 
   const summaryResult = client.callModel({
     model: opts.model,
@@ -199,6 +245,221 @@ export async function runAgent(config: AgentConfig, input: string | Message[], o
   // ...
 }
 ```
+
+---
+
+## Tool Result Offload
+
+Compaction handles context pressure *after* it builds up. This module prevents oversized tool results from entering context in the first place: when a tool returns more than a configurable byte budget, the full output is persisted to disk and the model sees only a preview plus a pointer. The model can retrieve more via a companion `read_persisted_result` tool.
+
+This is the same pattern Claude Code uses for oversized tool results (persist to disk, replace with ~2KB preview) and the same pattern Arize's Alyx uses for large JSON payloads (compressed preview + server-side copy the model drills into). A single oversized `grep` or `shell` output can otherwise consume tens of thousands of tokens on the very first turn.
+
+### When to use
+
+Enable this when the agent's tools can produce large outputs that may not all be relevant:
+
+- `shell` running builds, migrations, or log scrapes
+- `grep` against a large tree
+- `web_fetch` against verbose pages
+- Any custom tool that returns bulk data
+
+You generally do **not** need to offload `file_read` (it already paginates), `file_write`/`file_edit` (they return short confirmations), or `glob`/`list_dir` (capped by design).
+
+### src/tool-offload.ts
+
+An inline helper: each tool calls `offloadIfLarge(result, ctx, opts?)` at the end of its `execute`. If the serialized result is under the byte budget, it passes through unchanged; otherwise it gets written to disk and replaced with a preview + pointer. This pattern doesn't require refactoring the existing `tool({...})` exports in `references/tools.md` — the check just lives inside the tool's own `execute` body.
+
+```typescript
+import { resolve, sep } from 'path';
+import { mkdirSync, existsSync } from 'fs';
+
+export interface OffloadConfig {
+  /** Results larger than this are persisted. Default 50,000 bytes — matches Claude Code's per-tool cap. */
+  maxInlineBytes: number;
+  /** How many bytes of the head to keep inline as a preview. */
+  previewBytes: number;
+  /** Where to write persisted results. One file per call id. */
+  storageDir: string;
+}
+
+export const OFFLOAD_DEFAULTS: OffloadConfig = {
+  maxInlineBytes: 50_000,
+  previewBytes: 2_000,
+  storageDir: '.agent-state/tool-results',
+};
+
+/**
+ * If a tool's serialized result exceeds `maxInlineBytes`, persist it to disk
+ * and return a preview + pointer instead. Otherwise pass it through.
+ * Call from the end of a tool's execute function: `return offloadIfLarge(result, ctx)`.
+ *
+ * The storage directory is created lazily on first persist, not at import
+ * time, so enabling this module never fails startup in a read-only cwd.
+ */
+export async function offloadIfLarge<T>(
+  result: T,
+  ctx: { callId?: string } | undefined,
+  opts: Partial<OffloadConfig> = {},
+): Promise<T | {
+  preview: string;
+  truncated: true;
+  totalBytes: number;
+  persistedAt: string;
+  hint: string;
+}> {
+  const config = { ...OFFLOAD_DEFAULTS, ...opts };
+  const serialized = typeof result === 'string' ? result : JSON.stringify(result);
+
+  if (serialized.length <= config.maxInlineBytes) return result;
+
+  if (!existsSync(config.storageDir)) mkdirSync(config.storageDir, { recursive: true });
+
+  const callId = ctx?.callId ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const path = resolve(config.storageDir, `${callId}.txt`);
+  await Bun.write(path, serialized);
+
+  return {
+    preview: serialized.slice(0, config.previewBytes),
+    truncated: true,
+    totalBytes: serialized.length,
+    persistedAt: path,
+    hint: `Full output (${serialized.length} bytes) saved to ${path}. Use read_persisted_result({ path, offset, limit }) to read specific sections.`,
+  };
+}
+
+/**
+ * Validate that a path resolves to somewhere inside `storageDir`. Used by
+ * `read_persisted_result` to refuse arbitrary filesystem reads.
+ */
+export function isInsideStorageDir(path: string, storageDir: string): boolean {
+  const resolvedDir = resolve(storageDir) + sep;
+  const resolvedPath = resolve(path);
+  return resolvedPath === resolve(storageDir) || resolvedPath.startsWith(resolvedDir);
+}
+```
+
+### Patch your tools to use it
+
+No plain-object refactor needed. Add one line at the return sites of tools whose output can be large. For the `shell` tool defined in `references/tools.md`:
+
+```typescript
+// src/tools/shell.ts
+import { tool } from '@openrouter/agent/tool';
+import { z } from 'zod';
+import { offloadIfLarge } from '../tool-offload.js';
+
+export const shellTool = tool({
+  name: 'shell',
+  description: 'Execute a shell command and return stdout+stderr',
+  inputSchema: z.object({
+    command: z.string(),
+    timeout: z.number().optional(),
+  }),
+  execute: async ({ command, timeout }, ctx) => {
+    // ... existing spawn + capture + truncate logic ...
+    const result = { output, exitCode };
+    return offloadIfLarge(result, ctx);   // <-- one line, at the return
+  },
+});
+```
+
+Same pattern for `grep`, `web_fetch`, or any custom tool that can return bulk data. `file_read` already paginates, so skip it.
+
+### src/tools/read-persisted-result.ts
+
+The companion tool — the model needs a way to retrieve more of the persisted payload when the preview isn't enough. **Important**: this tool takes a `path` argument and must validate it stays inside the offload storage directory, otherwise it becomes a general-purpose file reader that can be pointed at anything on disk.
+
+It's exported as a factory so the storage dir can be passed in and wired from the same place that configures `offloadIfLarge`:
+
+```typescript
+import { tool } from '@openrouter/agent/tool';
+import { z } from 'zod';
+import { isInsideStorageDir } from '../tool-offload.js';
+
+const DEFAULT_LIMIT = 10_000;
+
+export function createReadPersistedResultTool(storageDir: string) {
+  return tool({
+    name: 'read_persisted_result',
+    description:
+      `Read a section of a previously-persisted oversized tool result. The path comes from a prior tool response\'s persistedAt field and must be inside the offload storage directory (${storageDir}). Supports offset/limit pagination; when output is truncated, the hint field tells you how to continue.`,
+    inputSchema: z.object({
+      path: z.string().describe('Path returned in a previous tool result\'s persistedAt field'),
+      offset: z.number().optional().describe('Byte offset to start from (default 0)'),
+      limit: z.number().optional().describe(`Max bytes to return (default ${DEFAULT_LIMIT})`),
+    }),
+    execute: async ({ path, offset = 0, limit = DEFAULT_LIMIT }) => {
+      if (!isInsideStorageDir(path, storageDir)) {
+        return { error: `Access denied: ${path} is outside the offload storage directory (${storageDir}).` };
+      }
+      try {
+        const buf = await Bun.file(path).arrayBuffer();
+        const total = buf.byteLength;
+        const end = Math.min(offset + limit, total);
+        const text = new TextDecoder().decode(new Uint8Array(buf).subarray(offset, end));
+        const truncated = end < total;
+        return {
+          content: text,
+          totalBytes: total,
+          ...(truncated && {
+            truncated: true,
+            nextOffset: end,
+            hint: `Showing bytes ${offset}-${end} of ${total}. Use offset=${end} to continue.`,
+          }),
+        };
+      } catch (err: any) {
+        if (err.code === 'ENOENT') return { error: `Persisted result not found: ${path}` };
+        return { error: err.message };
+      }
+    },
+  });
+}
+```
+
+### Wire into src/tools/index.ts
+
+Use a single `storageDir` constant so `offloadIfLarge` inside each tool and `createReadPersistedResultTool` in the registry agree on the location:
+
+```typescript
+import { serverTool } from '@openrouter/agent';
+import { OFFLOAD_DEFAULTS } from '../tool-offload.js';
+import { createReadPersistedResultTool } from './read-persisted-result.js';
+import { fileReadTool } from './file-read.js';
+import { fileWriteTool } from './file-write.js';
+import { fileEditTool } from './file-edit.js';
+import { globTool } from './glob.js';
+import { grepTool } from './grep.js';     // unchanged from references/tools.md
+import { shellTool } from './shell.js';   // unchanged — just calls offloadIfLarge inside execute
+import { listDirTool } from './list-dir.js';
+
+const STORAGE_DIR = OFFLOAD_DEFAULTS.storageDir;
+
+export const tools = [
+  fileReadTool,
+  fileWriteTool,
+  fileEditTool,
+  globTool,
+  listDirTool,
+  grepTool,                              // large tree → disk via offloadIfLarge
+  shellTool,                             // noisy build/test output → disk
+  createReadPersistedResultTool(STORAGE_DIR),  // so the model can drill into persisted payloads
+  serverTool({ type: 'openrouter:web_search' }),
+] as const;
+```
+
+If you want per-tool offload config (e.g. a larger budget for shell), pass the overrides to `offloadIfLarge` directly inside that tool and make sure its `storageDir` still matches the one passed to `createReadPersistedResultTool`.
+
+### Why not just truncate?
+
+Truncation loses information silently. With offload, the full output is on disk — if the model picked the wrong slice, it can ask for more. This matters especially for shell output where the error (and the tail) often matter more than the head, and for grep where the matches you care about may be anywhere in the list.
+
+### Cleanup
+
+Persisted files accumulate. Options:
+
+- **Per-session cleanup**: delete the `storageDir` when the CLI exits successfully.
+- **Age-based cleanup**: run a `find .agent-state/tool-results -mtime +7 -delete` in a cron or on startup.
+- **Session-scoped**: set `storageDir: .agent-state/tool-results/<sessionId>` so each run has its own directory.
 
 ---
 

--- a/skills/create-headless-agent/references/tools.md
+++ b/skills/create-headless-agent/references/tools.md
@@ -19,6 +19,9 @@ Read file contents with optional offset/limit. Full example in SKILL.md.
 
 - **inputSchema**: `path` (string), `offset?` (number, 1-indexed line), `limit?` (number, max lines)
 - **Behavior**: Read file with `await Bun.file(path).text()`, split lines, slice by offset/limit, return content + totalLines + truncated flag
+- **Default line cap**: When `limit` is omitted, return at most 2000 lines. The harness caps *even if the model didn't ask*, so the model never accidentally floods context with a 50k-line file. Pi and Claude Code both use this pattern (Pi: 2000 lines/50KB, Claude Code: 2000 lines + 256KB byte gate).
+- **Per-line truncation**: Truncate any single line longer than 2000 characters with a `… [line truncated, N chars dropped]` suffix. This dodges minified bundles and JSON dumps that would otherwise consume a whole output budget in one line. Count how many lines were affected so the model sees that fact in the hint — otherwise a 500-line file with one 10MB minified line would silently return incomplete content with `truncated: false`.
+- **Continuation hint**: When *anything* was truncated (tail OR any per-line truncation), set `truncated: true` and include a `hint` string explaining both forms of truncation. Example: `"Showing lines 1-2000 of 50000. Use offset=2001 to continue. 3 line(s) exceeded 2000 chars and were per-line truncated; use grep to fetch content from those lines."` The hint lives inside the returned JSON so the model actually sees it — a `truncated: true` boolean alone is easy to miss. `nextOffset` is only set when the *tail* was truncated, since line-based pagination can't recover per-line truncated content.
 - **Image detection**: Check extension for jpg/png/gif/webp — if image, read with `await Bun.file(path).arrayBuffer()`, convert to base64 via `Buffer.from(buf).toString('base64')`, and return `{ type: 'image', data, mimeType }`
 - **Read-only**
 

--- a/skills/create-headless-agent/sample/src/tools/file-read.ts
+++ b/skills/create-headless-agent/sample/src/tools/file-read.ts
@@ -1,13 +1,17 @@
 import { tool } from '@openrouter/agent/tool';
 import { z } from 'zod';
 
+const DEFAULT_LINE_LIMIT = 2000;
+const MAX_LINE_CHARS = 2000;
+
 export const fileReadTool = tool({
   name: 'file_read',
-  description: 'Read the contents of a file at the given path',
+  description:
+    'Read the contents of a file. Output is capped at 2000 lines by default (use offset/limit to paginate) and any line longer than 2000 characters is truncated. When the response is truncated, the hint field tells you how to continue.',
   inputSchema: z.object({
     path: z.string().describe('Absolute path to the file'),
     offset: z.number().optional().describe('Start reading from this line (1-indexed)'),
-    limit: z.number().optional().describe('Maximum number of lines to return'),
+    limit: z.number().optional().describe(`Maximum lines to return (default ${DEFAULT_LINE_LIMIT})`),
   }),
   execute: async ({ path, offset, limit }) => {
     try {
@@ -15,13 +19,27 @@ export const fileReadTool = tool({
       const lines = content.split('\n');
 
       const start = offset ? offset - 1 : 0;
-      const end = limit ? start + limit : lines.length;
-      const slice = lines.slice(start, end);
+      const end = Math.min(start + (limit ?? DEFAULT_LINE_LIMIT), lines.length);
+      let longLines = 0;
+      const slice = lines.slice(start, end).map((line) => {
+        if (line.length <= MAX_LINE_CHARS) return line;
+        longLines++;
+        return line.slice(0, MAX_LINE_CHARS) + `… [line truncated, ${line.length - MAX_LINE_CHARS} chars dropped]`;
+      });
+      const tailTruncated = end < lines.length;
+      const truncated = tailTruncated || longLines > 0;
+      const hintParts: string[] = [`Showing lines ${start + 1}-${end} of ${lines.length}.`];
+      if (tailTruncated) hintParts.push(`Use offset=${end + 1} to continue.`);
+      if (longLines > 0) hintParts.push(`${longLines} line(s) exceeded ${MAX_LINE_CHARS} chars and were per-line truncated; use grep to fetch content from those lines.`);
 
       return {
         content: slice.join('\n'),
         totalLines: lines.length,
-        ...(end < lines.length && { truncated: true, nextOffset: end + 1 }),
+        ...(truncated && {
+          truncated: true,
+          ...(tailTruncated && { nextOffset: end + 1 }),
+          hint: hintParts.join(' '),
+        }),
       };
     } catch (err: any) {
       if (err.code === 'ENOENT') return { error: `File not found: ${path}` };


### PR DESCRIPTION
## Summary

Three context-management improvements to the agent-scaffolding skills, borrowed from patterns documented in [Arize's "Context Management in Agent Harnesses"](https://x.com/aparnadhinak/status/2048492731929149929) article (Pi, OpenClaw, Claude Code, Letta).

- **Harden `file_read`** (both skills): default to 2000 lines even when `limit` is omitted, truncate any single line over 2000 chars, and surface both forms of truncation in a `hint` string the model actually sees. A 500-line file with one 10MB minified line now reports `truncated: true` with guidance to `grep` for the dropped content.
- **Tool-call/result boundary safety in compaction** (both skills): new `findSafeBoundary` helper walks the initial cut forward past any orphaned `tool` message or unresolved `assistant` with `tool_calls`, so the summarized half never ends on an unresolved call while the kept half starts with orphaned results.
- **Tool Result Offload module** (headless only): new optional module that persists oversized tool outputs to disk and replaces them with a preview + pointer, via a `offloadIfLarge(result, ctx)` helper tools call at their return site. Companion `createReadPersistedResultTool(storageDir)` factory refuses paths outside the configured storage dir, so enabling offload doesn't grant the model arbitrary filesystem read.

## Reviewer feedback addressed

Codex review flagged four P2 issues on the first pass, all addressed in this branch:
- `file_read` now reports `truncated: true` when any per-line truncation occurs (not just tail truncation)
- Offload wiring example is coherent with the existing `grepTool`/`shellTool` exports in `references/tools.md` (no plain-object refactor required)
- `mkdirSync` is lazy, moved into the branch that actually persists
- `read_persisted_result` validates path containment with `resolve()` + `startsWith()`

## Test plan

- [ ] `npx skills-ref validate skills/create-headless-agent` passes
- [ ] `npx skills-ref validate skills/create-agent-tui` passes
- [ ] Spot-check: scaffold a headless agent with the offload module enabled and confirm the generated `src/tool-offload.ts`, `src/tools/read-persisted-result.ts`, and `src/tools/index.ts` compile with `bunx tsc --noEmit`
- [ ] Spot-check: read a minified file via `file_read` and confirm the returned JSON has `truncated: true` and a `hint` mentioning per-line truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)