### PR TITLE
fix(openrouter-images): handle per-provider images[i] payload shapes

### DIFF
--- a/skills/openrouter-images/SKILL.md
+++ b/skills/openrouter-images/SKILL.md
@@ -112,6 +112,26 @@ The image-specific output item type is `image_generation_call` — this is not o
 
 This appears alongside standard `message` output items in the `output` array. Text and image outputs may each be absent depending on the model and prompt.
 
+## Provider Response Shapes (important)
+
+OpenRouter normalizes most fields, but the per-image payload inside `message.images[]` differs by provider:
+
+| Provider family | `images[i]` shape | Notes |
+|---|---|---|
+| Google Gemini (`google/gemini-*-image-*`) | plain string — either raw base64 or full `data:image/png;base64,...` URL | Original assumption baked into older versions of these scripts. |
+| OpenAI (`openai/gpt-5.4-image-2`, `openai/gpt-5-image*`) | object `{type:"image_url", image_url:{url:"data:image/png;base64,..."}}` | Will crash any code that calls `.startsWith` on the element directly. |
+
+The bundled `generate.ts` and `edit.ts` handle both shapes (string, `image_url.url`, `b64_json`, `url`, `data` fallbacks). If you write new tooling against the chat-completions modality response, normalize first:
+
+```ts
+const raw = message.images[i];
+const str =
+  typeof raw === "string"
+    ? raw
+    : raw?.image_url?.url ?? raw?.url ?? raw?.b64_json ?? raw?.data;
+const dataUrl = str.startsWith("data:") ? str : `data:image/png;base64,${str}`;
+```
+
 ## Using a Different Model
 
 The default model is `google/gemini-3.1-flash-image-preview` (Nano Banana 2). To use a different model, pass `--model <id>` with any OpenRouter model ID that supports image output modalities.

--- a/skills/openrouter-images/scripts/edit.ts
+++ b/skills/openrouter-images/scripts/edit.ts
@@ -65,7 +65,22 @@ if (images.length === 0) {
 
 const saved: string[] = [];
 for (let i = 0; i < images.length; i++) {
-  const img = images[i].startsWith("data:") ? images[i] : `data:image/png;base64,${images[i]}`;
+  const raw = images[i] as any;
+  let str: string;
+  if (typeof raw === "string") {
+    str = raw;
+  } else if (raw && typeof raw === "object") {
+    // Handle OpenAI-style {type:"image_url", image_url:{url:"..."}} or {b64_json:"..."}
+    str = raw.image_url?.url ?? raw.url ?? raw.b64_json ?? raw.data ?? "";
+    if (!str) {
+      console.error("Error: Unrecognized image payload shape:", JSON.stringify(raw).slice(0, 300));
+      process.exit(1);
+    }
+  } else {
+    console.error("Error: Unexpected image type:", typeof raw);
+    process.exit(1);
+  }
+  const img = str.startsWith("data:") ? str : `data:image/png;base64,${str}`;
   let outPath: string;
   if (images.length === 1) {
     outPath = outputBase;

--- a/skills/openrouter-images/scripts/generate.ts
+++ b/skills/openrouter-images/scripts/generate.ts
@@ -52,7 +52,22 @@ if (images.length === 0) {
 
 const saved: string[] = [];
 for (let i = 0; i < images.length; i++) {
-  const dataUrl = images[i].startsWith("data:") ? images[i] : `data:image/png;base64,${images[i]}`;
+  const raw = images[i];
+  let str: string;
+  if (typeof raw === "string") {
+    str = raw;
+  } else if (raw && typeof raw === "object") {
+    // Handle OpenAI-style {type:"image_url", image_url:{url:"..."}} or {b64_json:"..."}
+    str = raw.image_url?.url ?? raw.url ?? raw.b64_json ?? raw.data ?? "";
+    if (!str) {
+      console.error("Error: Unrecognized image payload shape:", JSON.stringify(raw).slice(0, 300));
+      process.exit(1);
+    }
+  } else {
+    console.error("Error: Unexpected image type:", typeof raw);
+    process.exit(1);
+  }
+  const dataUrl = str.startsWith("data:") ? str : `data:image/png;base64,${str}`;
   let outPath: string;
   if (images.length === 1) {
     outPath = outputBase;


### PR DESCRIPTION
## Problem

`openrouter-images/scripts/generate.ts` and `edit.ts` assume every entry in `message.images[]` is a string and call `.startsWith` on it directly. That holds for Google Gemini image models (the current default), but **OpenAI image models** (e.g. `openai/gpt-5.4-image-2`) return each entry as an object:

```json
{ "type": "image_url", "image_url": { "url": "data:image/png;base64,..." } }
```

So invoking the skill against any OpenAI image model crashes with `images[i].startsWith is not a function` and never saves an output. This is the same provider listed by `GET /api/v1/models` as image-capable, so it's a real path users hit when they pass `--model openai/...`.

## Fix

Normalize the per-element shape before building the `data:` URL, with fallbacks for the various wrappers OpenRouter / providers may emit:

```ts
const raw = images[i];
const str =
  typeof raw === 'string'
    ? raw
    : raw?.image_url?.url ?? raw?.url ?? raw?.b64_json ?? raw?.data;
const dataUrl = str.startsWith('data:') ? str : `data:image/png;base64,${str}`;
```

Applied to both `generate.ts` and `edit.ts`. Also added a **Provider Response Shapes** section to `SKILL.md` so future tooling that consumes the chat-completions image modality response handles the same case.

No behavior change for the existing default model — Gemini still returns a string and follows the original code path.

## Verification

End-to-end runs against the modified scripts (this branch):

- ✅ `google/gemini-3.1-flash-image-preview` (default, string shape) — `generate.ts` and `edit.ts` both produce a real image file
- ✅ `openai/gpt-5.4-image-2` (object shape, the original bug) — `generate.ts` now produces a real PNG (`1024x1024`) instead of crashing

## Files changed

- `skills/openrouter-images/scripts/generate.ts`
- `skills/openrouter-images/scripts/edit.ts`
- `skills/openrouter-images/SKILL.md` (new `Provider Response Shapes` section)