### PR TITLE
fix(openrouter-images): handle object-shape image payloads

### DIFF
--- a/skills/openrouter-images/scripts/edit.ts
+++ b/skills/openrouter-images/scripts/edit.ts
@@ -6,6 +6,7 @@ import {
   readImageAsDataUrl,
   saveImage,
   defaultOutputPath,
+  toDataUrl,
 } from "./lib.js";
 
 const apiKey = requireApiKey();
@@ -57,7 +58,7 @@ if (message.content) {
   console.error(`Model: ${message.content}`);
 }
 
-const images: string[] = message.images ?? [];
+const images: unknown[] = message.images ?? [];
 if (images.length === 0) {
   console.error("Error: No images returned by model.");
   process.exit(1);
@@ -65,7 +66,7 @@ if (images.length === 0) {
 
 const saved: string[] = [];
 for (let i = 0; i < images.length; i++) {
-  const img = images[i].startsWith("data:") ? images[i] : `data:image/png;base64,${images[i]}`;
+  const img = toDataUrl(images[i]);
   let outPath: string;
   if (images.length === 1) {
     outPath = outputBase;

--- a/skills/openrouter-images/scripts/generate.ts
+++ b/skills/openrouter-images/scripts/generate.ts
@@ -5,6 +5,7 @@ import {
   postChatCompletion,
   saveImage,
   defaultOutputPath,
+  toDataUrl,
 } from "./lib.js";
 
 const apiKey = requireApiKey();
@@ -44,7 +45,7 @@ if (message.content) {
   console.error(`Model: ${message.content}`);
 }
 
-const images: string[] = message.images ?? [];
+const images: unknown[] = message.images ?? [];
 if (images.length === 0) {
   console.error("Error: No images returned by model.");
   process.exit(1);
@@ -52,7 +53,7 @@ if (images.length === 0) {
 
 const saved: string[] = [];
 for (let i = 0; i < images.length; i++) {
-  const dataUrl = images[i].startsWith("data:") ? images[i] : `data:image/png;base64,${images[i]}`;
+  const dataUrl = toDataUrl(images[i]);
   let outPath: string;
   if (images.length === 1) {
     outPath = outputBase;

--- a/skills/openrouter-images/scripts/lib.ts
+++ b/skills/openrouter-images/scripts/lib.ts
@@ -103,3 +103,33 @@ export function defaultOutputPath(): string {
     `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
   return `image-${stamp}.png`;
 }
+
+/**
+ * Normalize an entry from `message.images` into a data-URL string.
+ *
+ * The chat-completions response shape for `images` varies by model:
+ *   - some models return a raw base64 string,
+ *   - some return a data URL string,
+ *   - others (e.g. openai/gpt-5.4-image-2, recent google/gemini-*-image
+ *     variants) return an object: `{ type: "image_url", image_url: { url } }`
+ *     or `{ b64_json: "..." }`.
+ *
+ * This helper accepts any of those and returns a `data:...;base64,...` URL
+ * suitable for `saveImage()`. It exits with a clean error on unrecognized
+ * shapes rather than throwing a `TypeError`.
+ */
+export function toDataUrl(entry: unknown): string {
+  let str: string | undefined;
+  if (typeof entry === "string") {
+    str = entry;
+  } else if (entry && typeof entry === "object") {
+    const e = entry as { image_url?: { url?: string }; url?: string; b64_json?: string; data?: string };
+    str = e.image_url?.url ?? e.url ?? e.b64_json ?? e.data;
+  }
+  if (typeof str !== "string" || str.length === 0) {
+    const preview = JSON.stringify(entry).slice(0, 200);
+    console.error(`Error: Unrecognized image payload shape in response: ${preview}`);
+    process.exit(1);
+  }
+  return str.startsWith("data:") ? str : `data:image/png;base64,${str}`;
+}


### PR DESCRIPTION
## Summary

`generate.ts` and `edit.ts` crash with `TypeError: images[i].startsWith is not a function` whenever the model returns image entries as objects rather than base64 strings — which is the current behavior for **every image model I tested**, including the documented default (`google/gemini-3.1-flash-image-preview`) and `openai/gpt-5.4-image-2`.

This PR introduces a small `toDataUrl()` helper in `lib.ts` that normalizes any of the shapes the API actually returns, and routes both scripts through it.

## Bug

The OpenRouter chat-completions response delivers `message.images[i]` as an object for several image-generation models today:

```jsonc
// openai/gpt-5.4-image-2
{ "type": "image_url", "image_url": { "url": "data:image/png;base64,iVBOR..." } }

// google/gemini-3.1-flash-image-preview (default model)
{ "type": "image_url", "image_url": { "url": "data:image/jpeg;base64,/9j/4..." } }
```

But both scripts type the field as `string[]` and call `.startsWith()` directly on each entry:

```ts
// skills/openrouter-images/scripts/generate.ts:55  (and edit.ts:68)
const images: string[] = message.images ?? [];
...
const dataUrl = images[i].startsWith("data:") ? images[i] : `data:image/png;base64,${images[i]}`;
//                          ^^^^^^^^^^ throws TypeError on objects
```

### Reproduction

Against `OpenRouterTeam/skills@main`, with a valid `OPENROUTER_API_KEY`:

```bash
$ git clone https://github.com/OpenRouterTeam/skills && cd skills/skills/openrouter-images/scripts
$ npm install
$ npx tsx generate.ts "a tiny red dot on white"
.../skills/openrouter-images/scripts/generate.ts:55
  const dataUrl = images[i].startsWith("data:") ? images[i] : `data:image/png;base64,${images[i]}`;
                            ^
TypeError: images[i].startsWith is not a function
```

Same crash for `--model openai/gpt-5.4-image-2`, and for `edit.ts` on the same code path.

## Fix

Add `toDataUrl(entry: unknown): string` to `lib.ts` and call it from both scripts. The helper normalizes:

| Shape | Source |
|---|---|
| raw base64 string | older / hypothetical models — preserved for back-compat |
| data URL string | back-compat |
| `{ image_url: { url } }` | `openai/gpt-5.4-image-2`, `google/gemini-3.1-flash-image-preview`, others |
| `{ url }` / `{ b64_json }` / `{ data }` | other variants observed in the wild |

into a `data:...;base64,...` URL ready for `saveImage()`. Unrecognized shapes hit a clean `console.error` + `process.exit(1)`, matching the surrounding error-handling style — no more raw `TypeError` stack traces.

The `images` array type in both scripts is widened from `string[]` to `unknown[]` so the helper owns the runtime narrowing.

```ts
// lib.ts
export function toDataUrl(entry: unknown): string {
  let str: string | undefined;
  if (typeof entry === "string") {
    str = entry;
  } else if (entry && typeof entry === "object") {
    const e = entry as { image_url?: { url?: string }; url?: string; b64_json?: string; data?: string };
    str = e.image_url?.url ?? e.url ?? e.b64_json ?? e.data;
  }
  if (typeof str !== "string" || str.length === 0) {
    const preview = JSON.stringify(entry).slice(0, 200);
    console.error(`Error: Unrecognized image payload shape in response: ${preview}`);
    process.exit(1);
  }
  return str.startsWith("data:") ? str : `data:image/png;base64,${str}`;
}
```

Diffstat: **3 files changed, 36 insertions(+), 4 deletions(-)**.

## Test Plan

End-to-end (`generate.ts` runs to completion and writes a valid image file):

- [x] `google/gemini-3.1-flash-image-preview` (default) — outputs a JPEG, 514 KB, `1408×768`
- [x] `openai/gpt-5.4-image-2` — outputs a PNG, 700 KB, `1024×1024`

Typecheck:

```bash
$ npm install --no-save typescript@5 @types/node
$ ./node_modules/.bin/tsc --noEmit --strict --target ES2022 \
    --module NodeNext --moduleResolution NodeNext --skipLibCheck \
    --types node lib.ts generate.ts edit.ts
# clean — exit 0
```

## Prior Art

| Item | Relationship |
|---|---|
| #17 `bug: network errors and JSON parse failures throw unhandled exceptions in lib.ts` | Adjacent — also touches `lib.ts`, but covers `res.json()` / `readImageAsDataUrl` / `saveImage` error paths. **No overlap** with this fix's image-shape normalization. |
| #14 `bug: search-models.ts --modality image returns vision/input-image models` | Different file (`openrouter-models`), unrelated. |
| #18 `chore: add metadata.json to openrouter-models, openrouter-images, openrouter-oauth` | Metadata-only, unrelated. |
| #11 `refactor: remove resolve-model.ts and search-models.ts` | Different skill, unrelated. |

No open or closed PR was found that addresses image-payload shape handling in `openrouter-images`.

## Notes

- Helper is colocated in `lib.ts` rather than a new file to keep the skill's `scripts/` minimal — consistent with the existing flat layout.
- I deliberately kept the back-compat string branches even though I couldn't reproduce a model returning a raw string today; the cost is one `typeof` check and it future-proofs against API shape changes / older models.
- Happy to split the helper out, rename, or add a unit test runner if reviewers prefer — just lmk.
