### PR TITLE
feat: add openrouter-stt skill

### DIFF
--- a/skills/openrouter-stt/README.md
+++ b/skills/openrouter-stt/README.md
@@ -1,0 +1,31 @@
+# openrouter-stt
+
+Transcribe speech to text via OpenRouter's `POST /api/v1/audio/transcriptions`. Covers basic usage with `curl`, model discovery, audio format selection, provider-specific options, and zero-dep TypeScript (`fetch`) and Python (`requests`) examples.
+
+## Install
+
+With the [GitHub CLI](https://cli.github.com/) (v2.90.0+):
+
+```bash
+gh skill install OpenRouterTeam/skills openrouter-stt
+```
+
+Works with Claude Code, Cursor, Codex, OpenCode, Gemini CLI, Windsurf, and [many more agents](https://cli.github.com/manual/gh_skill_install). Add `--scope user` to install across every project for your current agent, or `--agent claude-code` to target a specific agent.
+
+For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) see the [root README](../../README.md#installing).
+
+## Prerequisites
+
+- `OPENROUTER_API_KEY` environment variable. Get a key at [openrouter.ai/keys](https://openrouter.ai/keys).
+- `curl` and `jq` (for the bash workflow), or Python `requests` / TypeScript `fetch`.
+
+## What it covers
+
+See [SKILL.md](SKILL.md) for the full reference, including:
+
+- Why this endpoint is **not** OpenAI-compatible (base64 JSON body, not `multipart/form-data`)
+- A drop-in bash script that base64-encodes audio, posts JSON, and extracts the transcript
+- Discovering STT models via `/api/v1/models?output_modalities=transcription`
+- Audio format guidance (`wav`, `mp3`, `flac`, `m4a`, `ogg`, `webm`, `aac`) and avoiding format/bytes mismatch
+- Provider passthrough (`provider.options.<slug>`) for things like Groq's vocabulary `prompt`
+- Zero-dep TypeScript (`fetch`) and Python (`requests`) examples

--- a/skills/openrouter-stt/SKILL.md
+++ b/skills/openrouter-stt/SKILL.md
@@ -52,28 +52,30 @@ MODEL="google/chirp-3"
 FORMAT="wav"                          # wav, mp3, flac, m4a, ogg, webm, aac
 AUDIO="audio.wav"
 BODY=$(mktemp)
+PAYLOAD=$(mktemp)
 
 audio_b64=$(base64 < "$AUDIO" | tr -d '\n')
 
-payload=$(jq -n --arg model "$MODEL" --arg data "$audio_b64" --arg fmt "$FORMAT" \
-  '{model: $model, input_audio: {data: $data, format: $fmt}}')
+jq -n --arg model "$MODEL" --arg data "$audio_b64" --arg fmt "$FORMAT" \
+  '{model: $model, input_audio: {data: $data, format: $fmt}}' > "$PAYLOAD"
 
+# --data-binary @file keeps the base64 payload off argv (avoids E2BIG / ARG_MAX).
 http_code=$(curl -sS -X POST https://openrouter.ai/api/v1/audio/transcriptions \
   -H "Authorization: Bearer $OPENROUTER_API_KEY" \
   -H "Content-Type: application/json" \
   --output "$BODY" \
   -w '%{http_code}' \
-  -d "$payload")
+  --data-binary @"$PAYLOAD")
 
 if [[ "$http_code" != "200" ]]; then
   echo "STT failed (HTTP $http_code):" >&2
   cat "$BODY" >&2
-  rm -f "$BODY"
+  rm -f "$BODY" "$PAYLOAD"
   exit 1
 fi
 
 jq -r '.text' "$BODY"
-rm -f "$BODY"
+rm -f "$BODY" "$PAYLOAD"
 ```
 
 ## Discovering STT models

--- a/skills/openrouter-stt/SKILL.md
+++ b/skills/openrouter-stt/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: openrouter-stt
+description: Transcribe speech to text using OpenRouter's speech-to-text API. Use when the user asks to transcribe audio, convert speech to text, extract a transcript from a recording or meeting, caption a video's audio, or mentions STT, speech-to-text, ASR, or transcription.
+---
+
+# OpenRouter Speech-to-Text
+
+Transcribe audio via `POST /api/v1/audio/transcriptions` using `curl`. Requires `OPENROUTER_API_KEY` (get one at https://openrouter.ai/keys). If unset, stop and ask.
+
+**This endpoint is not OpenAI-compatible.** The body is JSON with base64 audio under `input_audio: { data, format }` — not `multipart/form-data` with a `file` field the way OpenAI's `/v1/audio/transcriptions` works. Do not point the OpenAI SDK at this endpoint; it will send the wrong shape. Use `curl`, `fetch`, or `requests` directly.
+
+## One call, JSON back
+
+Both request and response are JSON. The response body carries:
+
+- `text` — the transcript.
+- `usage` — `{ seconds, total_tokens, input_tokens, output_tokens, cost }`. Useful for logging and cost reconciliation.
+
+Sample response:
+
+```json
+{
+  "text": "Hello, this is a test of speech-to-text transcription.",
+  "usage": {
+    "seconds": 9.2,
+    "total_tokens": 113,
+    "input_tokens": 83,
+    "output_tokens": 30,
+    "cost": 0.000508
+  }
+}
+```
+
+One response header is worth keeping:
+
+- `X-Generation-Id` — unique ID for the request, useful for tracking, debugging, and cost lookups.
+
+## Drop-in workflow
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL="google/chirp-3"
+FORMAT="wav"                          # wav, mp3, flac, m4a, ogg, webm, aac
+AUDIO="audio.wav"
+HEADERS=$(mktemp)
+BODY=$(mktemp)
+
+audio_b64=$(base64 < "$AUDIO" | tr -d '\n')
+
+payload=$(jq -n --arg model "$MODEL" --arg data "$audio_b64" --arg fmt "$FORMAT" \
+  '{model: $model, input_audio: {data: $data, format: $fmt}}')
+
+http_code=$(curl -sS -X POST https://openrouter.ai/api/v1/audio/transcriptions \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -D "$HEADERS" \
+  --output "$BODY" \
+  -w '%{http_code}' \
+  -d "$payload")
+
+if [[ "$http_code" != "200" ]]; then
+  echo "STT failed (HTTP $http_code):" >&2
+  cat "$BODY" >&2
+  rm -f "$BODY" "$HEADERS"
+  exit 1
+fi
+
+gen_id=$(grep -i '^x-generation-id:' "$HEADERS" | awk '{print $2}' | tr -d '\r')
+jq -r '.text' "$BODY"
+echo "(generation_id=${gen_id:-unknown})" >&2
+rm -f "$BODY" "$HEADERS"
+```
+
+## Discovering STT models
+
+Filter the models endpoint by output modality to list transcription models.
+
+```bash
+curl -sS "https://openrouter.ai/api/v1/models?output_modalities=transcription" \
+  | jq '.data[] | {id, name, pricing}'
+```
+
+Models are provider-namespaced — use the full slug (`google/chirp-3`, `openai/whisper-1`, `openai/whisper-large-v3`), not the short name.
+
+## Parameters
+
+| Field                | Required | Notes                                                                                                     |
+| -------------------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `model`              | yes      | Full model slug from `/api/v1/models?output_modalities=transcription`.                                    |
+| `input_audio.data`   | yes      | Base64-encoded raw audio bytes. **Not** a data URI — just the base64 payload, no `data:audio/...;base64,` prefix. |
+| `input_audio.format` | yes      | `wav`, `mp3`, `flac`, `m4a`, `ogg`, `webm`, or `aac`. Must match the actual bytes. Support varies by provider. |
+| `language`           | no       | ISO-639-1 code (`en`, `ja`, `fr`). Auto-detected if omitted.                                              |
+| `temperature`        | no       | 0–1. Lower is more deterministic.                                                                         |
+| `provider`           | no       | Provider passthrough — see below.                                                                         |
+
+### Picking an audio format
+
+- **`wav`** / **`flac`** — uncompressed or lossless. Highest quality; largest uploads.
+- **`mp3`** / **`m4a`** / **`aac`** — compressed. Smaller payloads, which matters because base64 inflates bytes by ~33% on top of whatever the file already weighs.
+- **`webm`** / **`ogg`** — typical for browser recordings (`MediaRecorder`).
+
+The `format` field must match the actual container/codec of the bytes. A file saved as `.wav` that is actually mp3 will be rejected or mis-decoded. When in doubt, confirm with `ffprobe <file>`.
+
+## Provider-specific options
+
+Provider passthrough goes under `provider.options.<slug>` and is only forwarded when that provider handles the request. Example — Groq's `prompt` for vocabulary hinting:
+
+```json
+{
+  "model": "openai/whisper-large-v3",
+  "input_audio": { "data": "UklGRiQA...", "format": "wav" },
+  "provider": {
+    "options": {
+      "groq": {
+        "prompt": "Expected vocabulary: OpenRouter, API, transcription"
+      }
+    }
+  }
+}
+```
+
+Options keyed by provider slug are forwarded only when that provider matches; other keys are ignored. Check each provider's upstream docs for available passthrough keys.
+
+## TypeScript (fetch)
+
+```typescript
+import fs from "fs";
+
+const audio = await fs.promises.readFile("audio.wav");
+const data = audio.toString("base64");
+
+const res = await fetch("https://openrouter.ai/api/v1/audio/transcriptions", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    model: "google/chirp-3",
+    input_audio: { data, format: "wav" },
+  }),
+});
+
+if (!res.ok) {
+  throw new Error(`STT failed (HTTP ${res.status}): ${await res.text()}`);
+}
+
+const result = await res.json();
+console.log(result.text);
+```
+
+## Python (requests)
+
+```python
+import base64
+import os
+import requests
+
+with open("audio.wav", "rb") as f:
+    data = base64.b64encode(f.read()).decode("utf-8")
+
+res = requests.post(
+    "https://openrouter.ai/api/v1/audio/transcriptions",
+    headers={
+        "Authorization": f"Bearer {os.environ['OPENROUTER_API_KEY']}",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "google/chirp-3",
+        "input_audio": {"data": data, "format": "wav"},
+    },
+)
+res.raise_for_status()
+print(res.json()["text"])
+```
+
+## Troubleshooting
+
+**Garbled or empty `text`** — the `format` field probably doesn't match the actual bytes, or the audio is silent/corrupted. Confirm with `ffprobe audio.wav`.
+
+**400 with `"Invalid base64"` or silent failure** — `data` must be just base64, not a data URI (`data:audio/wav;base64,...`). Strip the prefix if you copied it from a browser `FileReader`.
+
+**400 with a `ZodError`** — a required field is missing or the wrong type. The body looks like `{"success":false,"error":{"name":"ZodError","message":"[...]"}}` — the nested `message` JSON string names the bad path (commonly `input_audio.data` or `input_audio.format`).
+
+**413 / request too large** — base64 inflates bytes by ~33%, so a large raw file becomes an even larger JSON payload. Use a smaller source file (compressed format, lower sample rate, or trimmed clip).
+
+**Model not found** — use the full slug from `/api/v1/models?output_modalities=transcription` (`google/chirp-3`, not `chirp-3`).
+
+## References
+
+- [STT guide](https://openrouter.ai/docs/guides/overview/multimodal/stt)
+- [Models page — filter to transcription output](https://openrouter.ai/models?output_modalities=transcription)

--- a/skills/openrouter-stt/SKILL.md
+++ b/skills/openrouter-stt/SKILL.md
@@ -14,15 +14,26 @@ Transcribe audio via `POST /api/v1/audio/transcriptions` using `curl`. Requires 
 Both request and response are JSON. The response body carries:
 
 - `text` — the transcript.
-- `usage` — `{ seconds, total_tokens, input_tokens, output_tokens, cost }`. Useful for logging and cost reconciliation.
+- `usage` — always includes `cost`. Providers additionally report either `seconds` of audio billed or a token breakdown (`total_tokens`, `input_tokens`, `output_tokens`), depending on how they price the request. Don't assume both are present.
 
-Sample response:
+Sample response (duration-priced provider, e.g. `google/chirp-3`):
+
+```json
+{
+  "text": "I used to rule the world.",
+  "usage": {
+    "seconds": 20,
+    "cost": 0.005333
+  }
+}
+```
+
+Sample response (token-priced provider):
 
 ```json
 {
   "text": "Hello, this is a test of speech-to-text transcription.",
   "usage": {
-    "seconds": 9.2,
     "total_tokens": 113,
     "input_tokens": 83,
     "output_tokens": 30,
@@ -30,10 +41,6 @@ Sample response:
   }
 }
 ```
-
-One response header is worth keeping:
-
-- `X-Generation-Id` — unique ID for the request, useful for tracking, debugging, and cost lookups.
 
 ## Drop-in workflow
 

--- a/skills/openrouter-stt/SKILL.md
+++ b/skills/openrouter-stt/SKILL.md
@@ -175,7 +175,10 @@ res = requests.post(
         "input_audio": {"data": data, "format": "wav"},
     },
 )
-res.raise_for_status()
+
+if not res.ok:
+    raise RuntimeError(f"STT failed (HTTP {res.status_code}): {res.text}")
+
 print(res.json()["text"])
 ```
 

--- a/skills/openrouter-stt/SKILL.md
+++ b/skills/openrouter-stt/SKILL.md
@@ -51,7 +51,6 @@ set -euo pipefail
 MODEL="google/chirp-3"
 FORMAT="wav"                          # wav, mp3, flac, m4a, ogg, webm, aac
 AUDIO="audio.wav"
-HEADERS=$(mktemp)
 BODY=$(mktemp)
 
 audio_b64=$(base64 < "$AUDIO" | tr -d '\n')
@@ -62,7 +61,6 @@ payload=$(jq -n --arg model "$MODEL" --arg data "$audio_b64" --arg fmt "$FORMAT"
 http_code=$(curl -sS -X POST https://openrouter.ai/api/v1/audio/transcriptions \
   -H "Authorization: Bearer $OPENROUTER_API_KEY" \
   -H "Content-Type: application/json" \
-  -D "$HEADERS" \
   --output "$BODY" \
   -w '%{http_code}' \
   -d "$payload")
@@ -70,14 +68,12 @@ http_code=$(curl -sS -X POST https://openrouter.ai/api/v1/audio/transcriptions \
 if [[ "$http_code" != "200" ]]; then
   echo "STT failed (HTTP $http_code):" >&2
   cat "$BODY" >&2
-  rm -f "$BODY" "$HEADERS"
+  rm -f "$BODY"
   exit 1
 fi
 
-gen_id=$(grep -i '^x-generation-id:' "$HEADERS" | awk '{print $2}' | tr -d '\r')
 jq -r '.text' "$BODY"
-echo "(generation_id=${gen_id:-unknown})" >&2
-rm -f "$BODY" "$HEADERS"
+rm -f "$BODY"
 ```
 
 ## Discovering STT models


### PR DESCRIPTION
Parallel to `openrouter-tts`, covering `POST /api/v1/audio/transcriptions`. Calls out that this endpoint is **not** OpenAI-compatible (JSON body with base64 `input_audio`, not `multipart/form-data`), and includes a curl+jq drop-in, model discovery, parameters table, provider passthrough, and zero-dep TypeScript (`fetch`) and Python (`requests`) examples.