### PR TITLE
docs(analytics): audit fixes for public launch

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -62,7 +62,7 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 | `granularity` | `string` | none | Time bucketing: `minute`, `hour`, `day`, `week`, `month` |
 | `time_range` | `object` | last 7 days | `{ start, end }` as ISO 8601 datetime strings |
 | `filters` | `object[]` | `[]` | Up to 20 filter conditions |
-| `order_by` | `object` | time desc (if granularity set) | `{ field, direction }` where field is a metric, dimension, or `"date"` |
+| `order_by` | `object` | time desc (if granularity set) | `{ field, direction }` where field is a metric, dimension, or `"date"` (short-form alias — maps to `date__day`, `date__hour`, etc. based on granularity) |
 | `limit` | `integer` | 1000 | Maximum total rows to return (1–10,000). On time-series queries with dimensions and no explicit `group_limit`, the server may raise this to accommodate the expected number of time-bucket/dimension combinations. |
 | `group_limit` | `integer` | auto-computed | Maximum rows per distinct dimension combination (ClickHouse LIMIT n BY). When omitted on time-series queries (granularity + dimensions), auto-computed from the time range to guarantee full time-window coverage per group. Explicit values override the default. Ignored when no dimensions are specified. |
 

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -89,19 +89,13 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 {
   "data": {
     "data": [
-      { "date": "2026-05-19 00:00:00", "model": "anthropic/claude-sonnet-4", "request_count": 1523, "total_usage": 4.27 },
-      { "date": "2026-05-18 00:00:00", "model": "openai/gpt-4o", "request_count": 892, "total_usage": 2.15 }
+      { "date__day": "2026-05-19", "model": "anthropic/claude-sonnet-4", "request_count": "1523", "total_usage": 4.27 },
+      { "date__day": "2026-05-18", "model": "openai/gpt-4o", "request_count": "892", "total_usage": 2.15 }
     ],
     "metadata": {
       "query_time_ms": 142,
       "row_count": 2,
       "truncated": false
-    },
-    "label_map": {
-      "api_key_id": { "123": "Production Key" },
-      "app": { "42": "My App" },
-      "user": { "user_abc": "alice@example.com" },
-      "workspace": { "ws-uuid-1": "Engineering" }
     },
     "cachedAt": 1747699200000
   }
@@ -112,12 +106,15 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 
 | Field | Description |
 |---|---|
-| `data.data` | Array of result rows. Each row has keys for requested metrics, dimensions, and `date` (when granularity is set) |
+| `data.data` | Array of result rows. Each row has keys for requested metrics, dimensions, and `date__<granularity>` (when granularity is set, e.g. `date__day`, `date__hour`) |
 | `data.metadata.query_time_ms` | Query execution time in milliseconds |
 | `data.metadata.row_count` | Number of rows returned |
 | `data.metadata.truncated` | `true` if results were truncated at the limit |
-| `data.label_map` | Maps raw dimension values to human-readable labels. Present when the query includes resolvable dimensions (`api_key_id`, `app`, `user`, `workspace`). Data rows already contain the resolved names — this map provides the original ID→name mapping |
 | `data.cachedAt` | Unix timestamp (ms) when the result was cached. Present when the response was served from cache |
+
+> **Numeric types:** Count metrics (`request_count`, `tokens_*`, etc.) are returned as strings (`"1523"`). Cost and rate metrics (`total_usage`, `cache_hit_rate`, latency, throughput) are returned as numbers (`4.27`). Parse count values with `Number()` or `parseInt()` before arithmetic.
+
+> **Label resolution:** Dimensions `api_key_id`, `app`, `user`, and `workspace` return human-readable labels in data rows (key names, app titles, user names, workspace names), not raw IDs.
 
 ## CLI Reference
 
@@ -142,19 +139,18 @@ The `query-analytics.ts` script in the `openrouter-analytics` skill accepts thes
 | `--limit` | Max total rows (1–10000) | `--limit 100` |
 | `--group-limit` | Max rows per dimension combination (1–10000). When omitted on time-series queries with dimensions, auto-computed server-side. | `--group-limit 50` |
 
-The CLI prints a single JSON object to **stdout** with three keys — `data` (the result rows), `metadata`, and `label_map` (present only when the query includes resolvable dimensions):
+The CLI prints a single JSON object to **stdout** with two keys — `data` (the result rows) and `metadata`:
 
 ```json
 {
   "data": [ { "model": "anthropic/claude-sonnet-4", "total_usage": 4.27 } ],
-  "metadata": { "query_time_ms": 142, "row_count": 2, "truncated": false },
-  "label_map": { "api_key_id": { "123": "Production Key" } }
+  "metadata": { "query_time_ms": 142, "row_count": 2, "truncated": false }
 }
 ```
 
 A human-readable stats line (row count, query time, truncation/cache flags) is written to **stderr** for terminal use only.
 
-> **When parsing output programmatically, always check `metadata.truncated`.** If `true`, the result was capped at `--limit` and is a *partial* dataset — increase `--limit` or paginate before reporting totals/rankings. Use `label_map` to resolve raw dimension IDs (`api_key_id`, `user`, `app`, `workspace`) to human-readable names.
+> **When parsing output programmatically, always check `metadata.truncated`.** If `true`, the result was capped at `--limit` and is a *partial* dataset — increase `--limit` or paginate before reporting totals/rankings. Dimensions `api_key_id`, `user`, `app`, and `workspace` are already resolved to human-readable names in the data rows.
 
 **Multi-filter queries:** the CLI builds a multi-element `filters` array (ANDed together) from the unindexed base flag (`--filter-field`/`--filter-op`/`--filter-value`) plus the indexed `--filter-field-N`/`--filter-op-N`/`--filter-value-N` flags. Each filter must supply all three parts (field, op, value); a partial triplet is rejected. Up to **20 filters** total (the base flag plus indices 1–19), matching the API cap. Indices may be sparse (e.g. base + `-2` with `-1` omitted is fine — gaps are skipped, not silently dropped). For a query like `model = X AND provider = Y`:
 
@@ -256,14 +252,11 @@ Combine up to 2 dimensions for cross-tabulation:
 | 429 | Rate limited (64 RPM) | Wait and retry |
 | 500 | Server error | Retry after a moment |
 
-## Data Source Behavior
+## Time Range Behavior
 
-The query engine automatically selects the optimal data source based on the requested metrics and dimensions:
+Some metric/dimension combinations support time ranges up to **365 days** (with daily granularity), while others are limited to **31 days**. The server resolves this automatically based on the requested metrics and dimensions.
 
-- If all requested metrics and dimensions are available in the materialized views → uses the MV (fast, up to 365 days)
-- If any metric or dimension requires raw generations data → uses the generations table (slower, up to 31 days)
-
-You do not control this directly — it is resolved automatically. If a query times out, it is likely hitting the generations table. Try:
-- Removing generations-only dimensions (`provider`, `origin`, `country`, `finish_reason`, etc.)
+If a query times out, try:
 - Narrowing the time range
 - Removing latency/throughput metrics
+- Removing per-generation dimensions (`provider`, `origin`, `country`, `finish_reason`, etc.)

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -57,26 +57,25 @@ Each metric has:
 | `display_label` | Human-readable label |
 | `is_rate` | Whether this is a ratio/rate (averaged, not summed) |
 
-### Data Sources
+### Time Range Limits
 
-The query engine uses two data sources and automatically picks the optimal one based on the requested metrics and dimensions:
-
-- **Materialized views (MV)** — Pre-aggregated. Fast, supports longer time ranges (up to 365 days for daily granularity). Available for most volume/cost metrics.
-- **Generations** — Raw generations table. Required for latency, throughput, and per-generation dimensions like `provider`, `origin`, `finish_reason`. Limited to 31-day range.
+Most volume and cost metrics support time ranges up to **365 days** with daily granularity. Latency/throughput metrics and some dimensions (`provider`, `origin`, `country`, `finish_reason`, `external_user`, `context_length_bucket`, `generation_id`) are limited to **31-day** time ranges. If a query times out, try narrowing the time range or removing latency/throughput metrics and per-generation dimensions.
 
 ### Metric Categories
 
 **Volume metrics** (how much):
-- `request_count` — number of API requests
-- `tokens_total`, `tokens_prompt`, `tokens_completion` — token counts
-- `reasoning_tokens` — tokens used for extended thinking
-- `cached_tokens` — tokens served from cache
-- `byok_request_count` — number of BYOK requests
+- `request_count` — number of API requests (up to 365 days)
+- `tokens_total`, `tokens_prompt`, `tokens_completion` — token counts (up to 365 days)
+- `reasoning_tokens` — tokens used for extended thinking (up to 365 days)
+- `cached_tokens` — tokens served from cache (up to 365 days)
+- `byok_request_count` — number of BYOK requests (up to 365 days)
+- `guardrail_invoked_count` — count of requests that triggered guardrails (31-day limit)
+- `response_cached_count` — count of responses served from cache (31-day limit)
 
 **Cost metrics** (how much money):
-- `total_usage` — total cost in USD
-- `byok_usage` — cost from bring-your-own-key requests
-- `credits_usage` — cost from credit-funded requests
+- `total_usage` — total cost in USD (up to 365 days)
+- `byok_usage` — BYOK (bring your own key) inference cost in USD (up to 365 days)
+- `credits_usage` — credits-based usage in USD (31-day limit)
 
 **Performance metrics** (how fast):
 - `avg_latency`, `p50_latency`, `p90_latency`, `p99_latency` — response latency in milliseconds
@@ -84,9 +83,7 @@ The query engine uses two data sources and automatically picks the optimal one b
 
 **Efficiency metrics** (how well):
 - `cache_hit_rate` — ratio of cached tokens to prompt tokens (0–1)
-- `guardrail_invoked_count` — number of requests that triggered guardrails
 - `guardrail_invoked_rate` — ratio of requests that triggered guardrails
-- `response_cached_count` — number of responses served from cache
 - `response_cached_rate` — ratio of responses served from cache
 
 ## Understanding Dimensions
@@ -104,26 +101,28 @@ You can combine up to 2 dimensions in a single query (e.g., `["model", "provider
 
 ### Label Resolution
 
-Some dimensions return raw IDs that the query endpoint automatically resolves to human-readable labels. When you query with these dimensions, data rows contain the resolved names and the response includes a `label_map` for the ID→name mapping:
+Some dimensions have their raw IDs automatically resolved to human-readable labels in query results. Data rows contain the resolved display names directly:
 
-| Dimension | Raw value | Resolved to |
-|---|---|---|
-| `api_key_id` | Numeric ID | Key name/label |
-| `app` | Numeric ID | App title or origin URL |
-| `user` | Clerk user ID | Email address |
-| `workspace` | UUID | Workspace name |
+| Dimension | Resolved to |
+|---|---|
+| `api_key_id` | Key name/label |
+| `app` | App title or origin URL |
+| `user` | User name or email address |
+| `workspace` | Workspace name |
 
 All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is without resolution.
 
+> Rows with an empty `user` value represent traffic not attributed to a specific org member (e.g., API keys created at the org level).
+
 ### Dimension Categories
 
-**Always available** (MV + generations):
+**Available with all time ranges:**
 - `model` — the OpenRouter model ID (permaslug)
 - `variant` — model variant (e.g., standard, extended)
 - `api_key_id` — which API key made the request
 - `user` — the creator user ID (for org-level queries)
 
-**Generations-only** (31-day limit):
+**Limited to 31-day time ranges:**
 - `generation_id` — unique ID for each generation (use to drill down to individual requests, then inspect via the `openrouter-generations` skill)
 - `provider` — upstream provider name
 - `origin` — request origin/source
@@ -180,7 +179,11 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "Latency trends" | `p90_latency` | — | Set `granularity: "hour"`, 31d limit |
 | "Usage by country" | `request_count` | `country` | Generations-only |
 | "How can I save money?" | `total_usage`, `cache_hit_rate`, `tokens_total` | `model` | See cost optimization in `openrouter-analytics` skill |
-| "Show me individual requests" | `total_usage`, `tokens_total` | `generation_id` | Generations-only. Use returned IDs with `openrouter-generations` skill for full metadata and content |
+| "Show me individual requests" | `total_usage`, `tokens_total` | `generation_id` | 31-day limit. Use returned IDs with `openrouter-generations` skill for full metadata and content |
+| "How much BYOK spend?" | `byok_usage` | `model` | Up to 365 days |
+| "BYOK vs credits split?" | `byok_usage`, `credits_usage` | — | `credits_usage` limited to 31 days |
+| "How many guardrail triggers?" | `guardrail_invoked_count`, `guardrail_invoked_rate` | `model` | 31-day limit |
+| "How many cached responses?" | `response_cached_count`, `response_cached_rate` | `model` | 31-day limit |
 
 ## Constraints
 
@@ -188,7 +191,7 @@ Use this guide to translate natural-language questions into the right metric/dim
 - Maximum 20 filters per query
 - Maximum 10,000 rows returned per query (default 1,000)
 - `group_limit` (1–10,000): controls max rows per dimension combination. Auto-computed on time-series queries with dimensions to guarantee full time-window coverage. Set explicitly to cap per-group rows (e.g., top N per model per day).
-- MV sources: up to 365 days for daily granularity
-- Generations source: up to 31 days
+- Most volume/cost metrics: up to 365 days with daily granularity
+- Latency/throughput metrics and per-generation dimensions: up to 31 days
 - Minute granularity: only available when the time window is ≤ 3 hours
 - Rate-limited to 64 requests per minute

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -172,12 +172,12 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "Which models cost the most?" | `total_usage` | `model` | Order by `total_usage` desc |
 | "How many requests?" | `request_count` | — | Add `model` or `api_key_id` for breakdown |
 | "How many tokens?" | `tokens_total` | — | Use `tokens_prompt` / `tokens_completion` for split |
-| "Which provider is fastest?" | `avg_latency`, `p90_latency` | `provider` | Generations-only, 31d limit |
+| "Which provider is fastest?" | `avg_latency`, `p90_latency` | `provider` | 31-day limit |
 | "What's my cache hit rate?" | `cache_hit_rate` | `model` | Rate metric — shows per-model caching |
 | "Which API key uses the most?" | `request_count`, `total_usage` | `api_key_id` | — |
 | "Usage over time" | `request_count` or `total_usage` | — | Set `granularity: "day"` |
 | "Latency trends" | `p90_latency` | — | Set `granularity: "hour"`, 31d limit |
-| "Usage by country" | `request_count` | `country` | Generations-only |
+| "Usage by country" | `request_count` | `country` | 31-day limit |
 | "How can I save money?" | `total_usage`, `cache_hit_rate`, `tokens_total` | `model` | See cost optimization in `openrouter-analytics` skill |
 | "Show me individual requests" | `total_usage`, `tokens_total` | `generation_id` | 31-day limit. Use returned IDs with `openrouter-generations` skill for full metadata and content |
 | "How much BYOK spend?" | `byok_usage` | `model` | Up to 365 days |

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -90,7 +90,7 @@ Usage by API key:
 npx tsx query-analytics.ts --metrics request_count,tokens_total --dimensions api_key_id --order-by request_count --limit 10
 ```
 
-Latency by provider (requires raw generations data, limited to 31-day range):
+Latency by provider (limited to 31-day range):
 
 ```bash
 npx tsx query-analytics.ts --metrics avg_latency,p90_latency --dimensions provider --order-by p90_latency
@@ -118,8 +118,8 @@ When interpreting results for the user:
 - **Latency** (`avg_latency`, `p50_latency`, etc.) is in milliseconds
 - **Rates** (`cache_hit_rate`) are 0–1 ratios
 - **Throughput** (`avg_throughput`) is tokens per second
-- When `granularity` is set, rows include a `date` field for the time bucket
-- **Label resolution**: dimensions `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (key name, app title, email, workspace name). The `query-analytics.ts` CLI emits a single stdout JSON object — `{ data, metadata, label_map }` — so the original ID→name mappings in `label_map` are available to agents capturing stdout (not just printed to the terminal)
+- When `granularity` is set, rows include a `date__<granularity>` field for the time bucket (e.g., `date__day`, `date__hour`, `date__month`)
+- **Label resolution**: dimensions `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (key name, app title, user name, workspace name) directly in the data rows
 - **Truncation**: when consuming output programmatically, check `metadata.truncated`. If `true`, the result was capped at `--limit` and is a *partial* dataset — raise `--limit` or paginate before reporting totals or rankings
 
 ### Cost Optimization Guidance

--- a/skills/openrouter-analytics/scripts/lib.ts
+++ b/skills/openrouter-analytics/scripts/lib.ts
@@ -23,8 +23,6 @@ interface QueryResponse {
     data: unknown[];
     metadata: { query_time_ms: number; row_count: number; truncated: boolean };
     cachedAt?: number;
-    // ID → human-readable label map for dimensions like api_key_id/app/user/workspace.
-    label_map?: Record<string, Record<string, string>>;
   };
 }
 

--- a/skills/openrouter-analytics/scripts/query-analytics.ts
+++ b/skills/openrouter-analytics/scripts/query-analytics.ts
@@ -148,13 +148,12 @@ const cached = data.cachedAt ? " (cached)" : "";
 // that agents capture from stdout.
 console.error(`Query: ${meta.row_count} rows in ${timeStr}ms${truncated}${cached}`);
 
-// Emit data, metadata, and label_map together on stdout. Agents parsing stdout
-// need metadata.truncated to know the result is partial, and label_map to
-// resolve dimension IDs (api_key_id, user, app, workspace) to human names —
-// both were previously discarded to stderr where stdout consumers never see them.
+// Emit data and metadata together on stdout. Agents parsing stdout
+// need metadata.truncated to know the result is partial.
+// Dimensions like api_key_id, user, app, workspace are already resolved
+// to human-readable names in the data rows.
 const out: Record<string, unknown> = {
   data: data.data,
   metadata: data.metadata,
 };
-if (data.label_map) out.label_map = data.label_map;
 console.log(JSON.stringify(out, null, 2));


### PR DESCRIPTION
## Summary

Skill doc fixes from the analytics API audit ahead of public launch. Addresses items 2–8 from the audit document.

**What changed:**

- **Removed internal data-source terminology** (`available_in`, `mv`, `generations`, materialized views) from all three skill docs. Reframed as user-observable time-range constraints (365-day vs 31-day limits).
- **Fixed time-series field name**: response examples and docs now use `date__<granularity>` (e.g. `date__day`) instead of `date`.
- **Added 5 missing metrics**: `guardrail_invoked_count`, `response_cached_count`, `byok_request_count`, `byok_usage`, `credits_usage` with time-range annotations.
- **Removed `label_map`** from response docs, CLI output format, and scripts (`lib.ts`, `query-analytics.ts`). The API no longer returns it; data rows contain resolved labels directly.
- **Documented numeric type inconsistency**: count metrics return as strings, cost/rate metrics as numbers.
- **Added BYOK/guardrail query patterns** to the question mapping table in the schema skill.
- **Documented empty `user` dimension** for unattributed org-level traffic.

Companion code change: [openrouter-web PR #22393](https://github.com/OpenRouterTeam/openrouter-web/pull/22393) drops `label_map` from the API response.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/fa69d543986a4cce8a4915403ceab84b
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->