### PR TITLE
docs(analytics): add 9 usage breakdown metrics to analytics skills

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -256,6 +256,8 @@ Combine up to 2 dimensions for cross-tabulation:
 
 Some metric/dimension combinations support time ranges up to **365 days** (with daily granularity), while others are limited to **31 days**. The server resolves this automatically based on the requested metrics and dimensions.
 
+Usage breakdown metrics follow the same pattern: `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, and `usage_upstream_web` support up to 365 days, while `usage_file`, `usage_upstream_file`, `usage_web_fetch`, and `usage_upstream_web_fetch` are limited to 31 days.
+
 If a query times out, try:
 - Narrowing the time range
 - Removing latency/throughput metrics

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -79,7 +79,7 @@ Most volume and cost metrics support time ranges up to **365 days** with daily g
 - `credits_usage` — credits-based usage in USD (31-day limit)
 - `usage_upstream` — provider-side (upstream) cost in USD (up to 365 days)
 - `usage_cache` — cache cost component in USD (up to 365 days)
-- `usage_data` — data logging discount in USD (up to 365 days)
+- `usage_data` — data logging cost adjustment in USD; typically negative when a data logging discount applies (up to 365 days)
 - `usage_web` — web search cost in USD (up to 365 days)
 - `usage_upstream_web` — provider-side web search cost in USD (up to 365 days)
 - `usage_file` — file processing cost in USD (31-day limit)
@@ -197,6 +197,7 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "Where does my spend go?" | `usage_upstream`, `usage_cache`, `usage_data` | — | Full cost breakdown (up to 365 days) |
 | "Web search costs?" | `usage_web`, `usage_upstream_web` | `model` | Up to 365 days |
 | "File processing costs?" | `usage_file`, `usage_upstream_file` | `model` | 31-day limit |
+| "Web fetch costs?" | `usage_web_fetch`, `usage_upstream_web_fetch` | `model` | 31-day limit |
 
 ## Constraints
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -77,6 +77,15 @@ Most volume and cost metrics support time ranges up to **365 days** with daily g
 - `total_usage` — total cost in USD (up to 365 days)
 - `byok_usage` — BYOK (bring your own key) inference cost in USD (up to 365 days)
 - `credits_usage` — credits-based usage in USD (31-day limit)
+- `usage_upstream` — provider-side (upstream) cost in USD (up to 365 days)
+- `usage_cache` — cache cost component in USD (up to 365 days)
+- `usage_data` — data logging discount in USD (up to 365 days)
+- `usage_web` — web search cost in USD (up to 365 days)
+- `usage_upstream_web` — provider-side web search cost in USD (up to 365 days)
+- `usage_file` — file processing cost in USD (31-day limit)
+- `usage_upstream_file` — provider-side file processing cost in USD (31-day limit)
+- `usage_web_fetch` — web fetch cost in USD (31-day limit)
+- `usage_upstream_web_fetch` — provider-side web fetch cost in USD (31-day limit)
 
 **Performance metrics** (how fast):
 - `avg_latency`, `p50_latency`, `p90_latency`, `p99_latency` — response latency in milliseconds
@@ -185,6 +194,9 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "BYOK vs credits split?" | `byok_usage`, `credits_usage` | — | `credits_usage` limited to 31 days |
 | "How many guardrail triggers?" | `guardrail_invoked_count`, `guardrail_invoked_rate` | `model` | 31-day limit |
 | "How many cached responses?" | `response_cached_count`, `response_cached_rate` | `model` | 31-day limit |
+| "Where does my spend go?" | `usage_upstream`, `usage_cache`, `usage_data` | — | Full cost breakdown (up to 365 days) |
+| "Web search costs?" | `usage_web`, `usage_upstream_web` | `model` | Up to 365 days |
+| "File processing costs?" | `usage_file`, `usage_upstream_file` | `model` | 31-day limit |
 
 ## Constraints
 

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -96,6 +96,12 @@ Latency by provider (limited to 31-day range):
 npx tsx query-analytics.ts --metrics avg_latency,p90_latency --dimensions provider --order-by p90_latency
 ```
 
+Usage cost breakdown (upstream, cache, data logging, web search):
+
+```bash
+npx tsx query-analytics.ts --metrics usage_upstream,usage_cache,usage_data,usage_web --granularity day
+```
+
 ## Common Query Templates
 
 ```bash
@@ -113,7 +119,7 @@ Returns a list of pre-built query templates for common questions, each with:
 The query endpoint returns an array of data rows. Each row is a flat object with keys matching the requested metrics and dimensions.
 
 When interpreting results for the user:
-- **Spend metrics** (`total_usage`) are in USD
+- **Spend metrics** (`total_usage`, `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, `usage_upstream_web`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, `usage_upstream_web_fetch`) are in USD
 - **Token counts** (`tokens_total`, `tokens_prompt`, `tokens_completion`) are in native model tokens
 - **Latency** (`avg_latency`, `p50_latency`, etc.) is in milliseconds
 - **Rates** (`cache_hit_rate`) are 0–1 ratios
@@ -127,11 +133,13 @@ When interpreting results for the user:
 When the user asks "How can I spend less?" or similar:
 
 1. Query top models by spend: `--metrics total_usage,tokens_total,cache_hit_rate,request_count --dimensions model --order-by total_usage --limit 10`
-2. Look for:
+2. Query cost breakdown: `--metrics usage_upstream,usage_cache,usage_data,usage_web,usage_file --granularity day` to see where spend goes
+3. Look for:
    - Models with high spend but low `cache_hit_rate` — prompt caching can help
    - Expensive models that could be replaced by cheaper alternatives for specific tasks
    - High token counts with low request counts — may indicate oversized prompts
    - Models where `reasoning_tokens` are a large fraction of total — consider disabling extended thinking if not needed
+   - High `usage_web` or `usage_file` relative to `usage_upstream` — web search and file processing add-on costs may be significant
 
 ## Drilling Down to Individual Generations
 

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -119,7 +119,7 @@ Returns a list of pre-built query templates for common questions, each with:
 The query endpoint returns an array of data rows. Each row is a flat object with keys matching the requested metrics and dimensions.
 
 When interpreting results for the user:
-- **Spend metrics** (`total_usage`, `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, `usage_upstream_web`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, `usage_upstream_web_fetch`) are in USD
+- **Spend metrics** (`total_usage`, `usage_upstream`, `usage_cache`, `usage_web`, `usage_upstream_web`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, `usage_upstream_web_fetch`) are in USD. `usage_data` is typically negative (a data logging discount)
 - **Token counts** (`tokens_total`, `tokens_prompt`, `tokens_completion`) are in native model tokens
 - **Latency** (`avg_latency`, `p50_latency`, etc.) is in milliseconds
 - **Rates** (`cache_hit_rate`) are 0–1 ratios


### PR DESCRIPTION
## Summary

Syncs the analytics skills with 9 new usage breakdown metrics added to the query builder in [openrouter-web#23926](https://github.com/OpenRouterTeam/openrouter-web/pull/23926).

New metrics: `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, `usage_upstream_web`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, `usage_upstream_web_fetch`.

**Schema skill** (`openrouter-analytics-schema`):
- Added all 9 metrics to the "Cost metrics" category with correct time range limits (365d for MV-backed, 31d for generations-only)
- Added 3 question→query mappings ("Where does my spend go?", "Web search costs?", "File processing costs?")

**Main analytics skill** (`openrouter-analytics`):
- Listed all usage breakdown metrics alongside `total_usage` in the spend interpretation guidance
- Added a cost breakdown CLI example
- Added cost breakdown step and web/file cost guidance to the cost optimization section

**Query skill** (`openrouter-analytics-query`):
- Documented the 365d vs 31d split for usage breakdown metrics in the "Time Range Behavior" section

Link to Devin session: https://openrouter.devinenterprise.com/sessions/751b45a95c3b4c6184826989bd6ac42a
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->