### PR TITLE
docs(analytics): fix dimension availability and label resolution drift

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -114,7 +114,7 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 
 > **Numeric types:** Count metrics (`request_count`, `tokens_*`, etc.) are returned as strings (`"1523"`). Cost and rate metrics (`total_usage`, `cache_hit_rate`, latency, throughput) are returned as numbers (`4.27`). Parse count values with `Number()` or `parseInt()` before arithmetic.
 
-> **Label resolution:** Dimensions `api_key_id`, `app`, `user`, and `workspace` return human-readable labels in data rows (key names, app titles, user names, workspace names), not raw IDs.
+> **Label resolution:** Dimensions `model`, `api_key_id`, `app`, `user`, and `workspace` return human-readable labels in data rows (model display names, key names, app titles, user names, workspace names), not raw IDs.
 
 ## CLI Reference
 
@@ -150,7 +150,7 @@ The CLI prints a single JSON object to **stdout** with two keys — `data` (the 
 
 A human-readable stats line (row count, query time, truncation/cache flags) is written to **stderr** for terminal use only.
 
-> **When parsing output programmatically, always check `metadata.truncated`.** If `true`, the result was capped at `--limit` and is a *partial* dataset — increase `--limit` or paginate before reporting totals/rankings. Dimensions `api_key_id`, `user`, `app`, and `workspace` are already resolved to human-readable names in the data rows.
+> **When parsing output programmatically, always check `metadata.truncated`.** If `true`, the result was capped at `--limit` and is a *partial* dataset — increase `--limit` or paginate before reporting totals/rankings. Dimensions `model`, `api_key_id`, `user`, `app`, and `workspace` are already resolved to human-readable names in the data rows.
 
 **Multi-filter queries:** the CLI builds a multi-element `filters` array (ANDed together) from the unindexed base flag (`--filter-field`/`--filter-op`/`--filter-value`) plus the indexed `--filter-field-N`/`--filter-op-N`/`--filter-value-N` flags. Each filter must supply all three parts (field, op, value); a partial triplet is rejected. Up to **20 filters** total (the base flag plus indices 1–19), matching the API cap. Indices may be sparse (e.g. base + `-2` with `-1` omitted is fine — gaps are skipped, not silently dropped). For a query like `model = X AND provider = Y`:
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -115,31 +115,32 @@ Some dimensions have their raw IDs automatically resolved to human-readable labe
 
 | Dimension | Resolved to |
 |---|---|
-| `api_key_id` | Key name/label |
-| `app` | App title or origin URL |
+| `model` | Formatted model name (shortened display name) |
+| `api_key_id` | Key name/label (with `-1` sentinel surfaced as "Chatroom") |
+| `app` | App title or origin URL (with `-1` sentinel surfaced as "Unknown") |
 | `user` | User name or email address |
 | `workspace` | Workspace name |
 
-All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is without resolution.
+All other dimensions (e.g., `provider`, `country`, `origin`) are returned as-is without resolution.
 
 > Rows with an empty `user` value represent traffic not attributed to a specific org member (e.g., API keys created at the org level).
 
 ### Dimension Categories
 
-**Available with all time ranges:**
+**Available with all time ranges (up to 365 days via daily MV):**
 - `model` — the OpenRouter model ID (permaslug)
 - `variant` — model variant (e.g., standard, extended)
 - `api_key_id` — which API key made the request
+- `workspace` — workspace UUID
+- `app` — application ID
 - `user` — the creator user ID (for org-level queries)
 
-**Limited to 31-day time ranges:**
+**Limited to 31-day time ranges (generations table only):**
 - `generation_id` — unique ID for each generation (use to drill down to individual requests, then inspect via the `openrouter-generations` skill)
 - `provider` — upstream provider name
 - `origin` — request origin/source
 - `country` — request country
 - `finish_reason` — why the generation ended (stop, length, etc.)
-- `workspace` — workspace ID
-- `app` — application ID
 - `external_user` — custom user ID passed by the caller
 - `context_length_bucket` — bucketed context length (1K, 10K, 100K, etc.)
 

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -125,7 +125,7 @@ When interpreting results for the user:
 - **Rates** (`cache_hit_rate`) are 0–1 ratios
 - **Throughput** (`avg_throughput`) is tokens per second
 - When `granularity` is set, rows include a `date__<granularity>` field for the time bucket (e.g., `date__day`, `date__hour`, `date__month`)
-- **Label resolution**: dimensions `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (key name, app title, user name, workspace name) directly in the data rows
+- **Label resolution**: dimensions `model`, `api_key_id`, `app`, `user`, and `workspace` have their raw values replaced with human-readable names (model display name, key name, app title, user name, workspace name) directly in the data rows
 - **Truncation**: when consuming output programmatically, check `metadata.truncated`. If `true`, the result was capped at `--limit` and is a *partial* dataset — raise `--limit` or paginate before reporting totals or rankings
 
 ### Cost Optimization Guidance


### PR DESCRIPTION
## Summary

Three drift items between the query builder (`packages/clickhouse/analytics/`) and the analytics skills:

1. **`workspace` and `app` dimensions** were listed under "Limited to 31-day time ranges" but both have MV columns since migration 106 (`availableIn: ['mv', 'generations']`). Moved to "Available with all time ranges (up to 365 days via daily MV)".

2. **`model` label resolution** was undocumented — `dimension-labels.ts` resolves permaslugs to formatted display names via `formatModelName`, but skills said model was "returned as-is without resolution". Added `model` to the label resolution table in all three skill files.

3. **Sentinel labels** for `api_key_id` (`-1` → "Chatroom") and `app` (`-1` → "Unknown") now documented in the resolution table.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/a4acf40ef48e4b9fb004a2b0feac1a27
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->