### PR TITLE
docs: clarify router vs model slug in analytics-schema and generations skills

### DIFF
--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -127,7 +127,7 @@ All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is w
 ### Dimension Categories
 
 **Available with all time ranges:**
-- `model` — the resolved model that actually served the generation (permaslug, e.g., `openai/gpt-4o`). For routed requests, this is the downstream model the router chose — not the router itself. To analyze router traffic, filter on the router field instead.
+- `model` — the resolved model that actually served the generation (permaslug, e.g., `openai/gpt-4o`). For routed requests, this is the downstream model the router chose — not the router itself. To identify router traffic, drill down to individual generations via `generation_id` and check the `router` field using the `openrouter-generations` skill, or query `router_permaslug` in ClickHouse directly.
 - `variant` — model variant (e.g., standard, extended)
 - `api_key_id` — which API key made the request
 - `user` — the creator user ID (for org-level queries)

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -127,7 +127,7 @@ All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is w
 ### Dimension Categories
 
 **Available with all time ranges:**
-- `model` — the OpenRouter model ID (permaslug)
+- `model` — the resolved model that actually served the generation (permaslug, e.g., `openai/gpt-4o`). For routed requests, this is the downstream model the router chose — not the router itself. To analyze router traffic, filter on the router field instead.
 - `variant` — model variant (e.g., standard, extended)
 - `api_key_id` — which API key made the request
 - `user` — the creator user ID (for org-level queries)

--- a/skills/openrouter-generations/SKILL.md
+++ b/skills/openrouter-generations/SKILL.md
@@ -44,7 +44,7 @@ npx tsx get-generation.ts --id gen-1234567890 --json
 
 **What you get back:**
 
-- **Model & routing**: `model`, `provider_name`, `router`, `service_tier`
+- **Model & routing**: `model` (resolved model that served the request), `provider_name`, `router` (the router that chose the model, if any), `service_tier`
 - **Tokens**: `tokens_prompt`, `tokens_completion`, `native_tokens_reasoning`, `native_tokens_cached`
 - **Cost**: `total_cost`, `usage`, `upstream_inference_cost`, `cache_discount`
 - **Performance**: `latency`, `generation_time`, `moderation_latency`
@@ -201,7 +201,7 @@ If you have a `request_id` or `session_id` from one generation, you can find rel
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string | Generation ID (`gen-...`) |
-| `model` | string | Model permaslug (e.g., `openai/gpt-4o`) |
+| `model` | string | Resolved model permaslug (e.g., `openai/gpt-4o`). For routed requests, this is the downstream model the router chose — not the router slug. |
 | `provider_name` | string\|null | Provider that served the request |
 | `api_type` | string | One of: `completions`, `embeddings`, `rerank`, `tts`, `stt`, `video` |
 | `tokens_prompt` | int\|null | Prompt token count |
@@ -224,7 +224,7 @@ If you have a `request_id` or `session_id` from one generation, you can find rel
 | `external_user` | string\|null | External user identifier (X-External-User header) |
 | `session_id` | string\|null | Session grouping ID |
 | `request_id` | string\|null | Request grouping ID (all gens from one API call) |
-| `router` | string\|null | Router used (e.g., `openrouter/auto`) |
+| `router` | string\|null | Router that selected the model (e.g., `openrouter/auto`, `openrouter/fusion`). Null when the user explicitly chose a model. Use this — not `model` — to identify router traffic. |
 | `service_tier` | string\|null | Provider service tier |
 | `web_search_engine` | string\|null | Search engine used (e.g., `exa`, `firecrawl`) |
 | `num_search_results` | int\|null | Number of search results included |


### PR DESCRIPTION
## Summary

Companion to the data-warehouse and Looker PRs — updates skills so agents using the OpenRouter Analytics and Generations APIs understand the router vs model slug distinction.

- **`openrouter-analytics-schema`**: `model` dimension description now states it's the resolved downstream model, not the router, and directs to the router field for router traffic.
- **`openrouter-generations`**: `model` field description clarifies it's the resolved model; `router` field description explains it identifies the router and should be used for router traffic. The "What you get back" summary also clarifies the relationship.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/65ba8131d98d4c32a2995b7ba0829d7c
Requested by: @Justin-Summerville