### PR TITLE
docs(analytics): sync skills with query builder changes (2026-06-17)

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -59,12 +59,31 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `dimensions` | `string[]` | `[]` | Up to 2 dimensions to group by |
+| `classifier_dimensions` | `object` | none | Dynamic dimensions from a classifier join table. See below. |
 | `granularity` | `string` | none | Time bucketing: `minute`, `hour`, `day`, `week`, `month` |
 | `time_range` | `object` | last 7 days | `{ start, end }` as ISO 8601 datetime strings |
 | `filters` | `object[]` | `[]` | Up to 20 filter conditions |
 | `order_by` | `object` | time desc (if granularity set) | `{ field, direction }` where field is a metric, dimension, or `"date"` (short-form alias — maps to `date__day`, `date__hour`, etc. based on granularity) |
 | `limit` | `integer` | 1000 | Maximum total rows to return (1–10,000). On time-series queries with dimensions and no explicit `group_limit`, the server may raise this to accommodate the expected number of time-bucket/dimension combinations. |
 | `group_limit` | `integer` | auto-computed | Maximum rows per distinct dimension combination (ClickHouse LIMIT n BY). When omitted on time-series queries (granularity + dimensions), auto-computed from the time range to guarantee full time-window coverage per group. Explicit values override the default. Ignored when no dimensions are specified. |
+
+### Classifier Dimensions
+
+Use `classifier_dimensions` to group by dynamic labels from a classifier join table:
+
+```json
+{
+  "classifier_dimensions": {
+    "classifier_id": "uuid-of-classifier",
+    "dimension_names": ["category", "sentiment"]
+  }
+}
+```
+
+- `classifier_id` (required): UUID of the classifier
+- `dimension_names` (optional): specific fields to include (max 10). Omit for all fields.
+
+Classifier dimensions force the query to the raw generations table (31-day limit). They can be used alongside regular `dimensions`.
 
 ### Filter Object Shape
 
@@ -74,6 +93,7 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 
 - Scalar operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`): `value` is a string or number
 - Array operators (`in`, `not_in`): `value` is an array of strings or numbers
+- For `api_key_id` filters: you can pass either the numeric internal ID or the 64-character SHA-256 hash from the keys API. Hashes are auto-resolved to numeric IDs before querying.
 
 ### Order By
 
@@ -256,7 +276,7 @@ Combine up to 2 dimensions for cross-tabulation:
 
 Some metric/dimension combinations support time ranges up to **365 days** (with daily granularity), while others are limited to **31 days**. The server resolves this automatically based on the requested metrics and dimensions.
 
-Usage breakdown metrics follow the same pattern: `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, and `usage_upstream_web` support up to 365 days, while `usage_file`, `usage_upstream_file`, `usage_web_fetch`, and `usage_upstream_web_fetch` are limited to 31 days.
+Usage breakdown metrics follow the same pattern: `credits_usage`, `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, and `usage_upstream_web` support up to 365 days, while `openrouter_usage`, `byok_fees`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, and `usage_upstream_web_fetch` are limited to 31 days. Classifier dimensions (`classifier_dimensions` field) always force the 31-day generations table.
 
 If a query times out, try:
 - Narrowing the time range

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -74,7 +74,7 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 
 - Scalar operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`): `value` is a string or number
 - Array operators (`in`, `not_in`): `value` is an array of strings or numbers
-- For `api_key_id` filters: you can pass either the numeric internal ID or the 64-character SHA-256 hash from the keys API. Hashes are auto-resolved to numeric IDs before querying.
+- For `api_key_id` filters: you can pass the numeric ID (returned in generation metadata and label-resolved query results) or the 64-character SHA-256 hash (returned by `GET /api/v1/keys`). Hashes are auto-resolved to numeric IDs before querying.
 
 ### Order By
 

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -59,31 +59,12 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `dimensions` | `string[]` | `[]` | Up to 2 dimensions to group by |
-| `classifier_dimensions` | `object` | none | Dynamic dimensions from a classifier join table. See below. |
 | `granularity` | `string` | none | Time bucketing: `minute`, `hour`, `day`, `week`, `month` |
 | `time_range` | `object` | last 7 days | `{ start, end }` as ISO 8601 datetime strings |
 | `filters` | `object[]` | `[]` | Up to 20 filter conditions |
 | `order_by` | `object` | time desc (if granularity set) | `{ field, direction }` where field is a metric, dimension, or `"date"` (short-form alias — maps to `date__day`, `date__hour`, etc. based on granularity) |
 | `limit` | `integer` | 1000 | Maximum total rows to return (1–10,000). On time-series queries with dimensions and no explicit `group_limit`, the server may raise this to accommodate the expected number of time-bucket/dimension combinations. |
 | `group_limit` | `integer` | auto-computed | Maximum rows per distinct dimension combination (ClickHouse LIMIT n BY). When omitted on time-series queries (granularity + dimensions), auto-computed from the time range to guarantee full time-window coverage per group. Explicit values override the default. Ignored when no dimensions are specified. |
-
-### Classifier Dimensions
-
-Use `classifier_dimensions` to group by dynamic labels from a classifier join table:
-
-```json
-{
-  "classifier_dimensions": {
-    "classifier_id": "uuid-of-classifier",
-    "dimension_names": ["category", "sentiment"]
-  }
-}
-```
-
-- `classifier_id` (required): UUID of the classifier
-- `dimension_names` (optional): specific fields to include (max 10). Omit for all fields.
-
-Classifier dimensions force the query to the raw generations table (31-day limit). They can be used alongside regular `dimensions`.
 
 ### Filter Object Shape
 
@@ -276,7 +257,7 @@ Combine up to 2 dimensions for cross-tabulation:
 
 Some metric/dimension combinations support time ranges up to **365 days** (with daily granularity), while others are limited to **31 days**. The server resolves this automatically based on the requested metrics and dimensions.
 
-Usage breakdown metrics follow the same pattern: `credits_usage`, `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, and `usage_upstream_web` support up to 365 days, while `openrouter_usage`, `byok_fees`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, and `usage_upstream_web_fetch` are limited to 31 days. Classifier dimensions (`classifier_dimensions` field) always force the 31-day generations table.
+Usage breakdown metrics follow the same pattern: `credits_usage`, `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, and `usage_upstream_web` support up to 365 days, while `openrouter_usage`, `byok_fees`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, and `usage_upstream_web_fetch` are limited to 31 days.
 
 If a query times out, try:
 - Narrowing the time range

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -74,7 +74,13 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 
 - Scalar operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`): `value` is a string or number
 - Array operators (`in`, `not_in`): `value` is an array of strings or numbers
-- For `api_key_id` filters: you can pass the numeric ID (returned in generation metadata and label-resolved query results) or the 64-character SHA-256 hash (returned by `GET /api/v1/keys`). Hashes are auto-resolved to numeric IDs before querying.
+- Several dimensions are **label-resolved** in query results (returned as human-readable names), but filters must use the underlying ID:
+  - `api_key_id` — numeric ID (from generation metadata) or 64-char SHA-256 hash (from `GET /api/v1/keys`). Hashes are auto-resolved to numeric IDs before querying.
+  - `user` — Clerk user ID (e.g. `user_abc123`), not the display name/email shown in results.
+  - `workspace` — workspace UUID, not the workspace name shown in results.
+  - `app` — numeric app ID, not the app title shown in results.
+  - `model` — permaslug (e.g. `openai/gpt-4o`), not the display name.
+- Other dimensions (`provider`, `origin`, `country`, `finish_reason`, `external_user`, etc.) are not enriched — filter values match what's returned in results.
 
 ### Order By
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -203,14 +203,19 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "File processing costs?" | `usage_file`, `usage_upstream_file` | `model` | 31-day limit |
 | "Web fetch costs?" | `usage_web_fetch`, `usage_upstream_web_fetch` | `model` | 31-day limit |
 
-## API Key Hash Filters
+## Filter Value Reference
 
-When filtering by `api_key_id`, you can pass:
+Several dimensions are **label-resolved** in query results — the response shows human-readable names, but filters must use the underlying ID. Here's where to find each:
 
-- The **numeric ID** — found in generation metadata (the `api_key_id` field on each generation) and in label-resolved analytics query results.
-- The **64-character SHA-256 hash** — returned by `GET /api/v1/keys` as the `key_hash` field.
+| Dimension | Filter value | Where to find it |
+|---|---|---|
+| `api_key_id` | Numeric ID **or** 64-char SHA-256 hash | Numeric ID: generation metadata (`api_key_id` field). Hash: `GET /api/v1/keys` (`key_hash` field). Hashes are auto-resolved server-side. If a hash can't be resolved, a sentinel value returns zero rows (no error). |
+| `user` | Clerk user ID (e.g. `user_abc123`) | User settings or org member list — not the display name/email shown in results. |
+| `workspace` | Workspace UUID | Workspace settings page or `GET /api/v1/workspaces` — not the workspace name shown in results. |
+| `app` | Numeric app ID | Generation metadata (`app_id` field) or app settings — not the app title shown in results. |
+| `model` | Permaslug (e.g. `openai/gpt-4o`) | Model page URL or `GET /api/v1/models` — not the display name. |
 
-Hash values are automatically resolved to numeric IDs before querying ClickHouse. If a hash cannot be resolved, the filter uses a sentinel value that returns zero rows (no error).
+Other dimensions (`provider`, `origin`, `country`, `finish_reason`, `external_user`, etc.) are not enriched — filter values match what's returned in results.
 
 ## Constraints
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -203,35 +203,13 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "File processing costs?" | `usage_file`, `usage_upstream_file` | `model` | 31-day limit |
 | "Web fetch costs?" | `usage_web_fetch`, `usage_upstream_web_fetch` | `model` | 31-day limit |
 
-## Classifier Dimensions
-
-The query builder supports dynamic dimensions backed by a classifier join table (`generation_classifications`). These allow grouping generations by custom classification labels (e.g., category, sentiment) without adding static columns to the schema.
-
-To use classifier dimensions, add the `classifier_dimensions` field to your query request:
-
-```json
-{
-  "metrics": ["request_count", "total_usage"],
-  "classifier_dimensions": {
-    "classifier_id": "my-classifier-uuid",
-    "dimension_names": ["category", "sentiment"]
-  },
-  "granularity": "day"
-}
-```
-
-- `classifier_id` (required) — the UUID of the classifier whose labels to group by
-- `dimension_names` (optional) — array of specific dimension field names within the classifier. If omitted, all dimensions for the classifier are included (max 10).
-
-Classifier dimensions are always resolved against the raw generations table (31-day time range limit) via a LEFT JOIN. They cannot be combined with materialized-view-only queries.
-
 ## API Key Hash Filters
 
 When filtering by `api_key_id`, you can pass either the numeric internal ID or the 64-character SHA-256 hash exposed by the keys API. Hash values are automatically resolved to numeric IDs before querying ClickHouse. If a hash cannot be resolved, the filter uses a sentinel value that returns zero rows (no error).
 
 ## Constraints
 
-- Maximum 2 dimensions per query (plus optional classifier dimensions)
+- Maximum 2 dimensions per query
 - Maximum 20 filters per query
 - Maximum 10,000 rows returned per query (default 1,000)
 - `group_limit` (1–10,000): controls max rows per dimension combination. Auto-computed on time-series queries with dimensions to guarantee full time-window coverage. Set explicitly to cap per-group rows (e.g., top N per model per day).

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -78,7 +78,7 @@ Most volume and cost metrics support time ranges up to **365 days** with daily g
 - `byok_usage` — BYOK (bring your own key) inference cost in USD (up to 365 days)
 - `credits_usage` — all charges billed to OpenRouter credits in USD, including BYOK platform fees (up to 365 days)
 - `openrouter_usage` — non-BYOK inference spend in USD; excludes requests made with user-provided keys (31-day limit)
-- `byok_fees` — BYOK platform fees in USD; the margin charged on top of BYOK inference cost (31-day limit)
+- `byok_fees` — BYOK platform fees in USD; the platform fee portion of `credits_usage` charged on BYOK requests (31-day limit). `credits_usage` includes both non-BYOK inference charges and these BYOK platform fees.
 - `usage_upstream` — provider-side (upstream) cost in USD (up to 365 days)
 - `usage_cache` — cache cost component in USD (up to 365 days)
 - `usage_data` — data logging cost adjustment in USD; typically negative when a data logging discount applies (up to 365 days)

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -74,9 +74,11 @@ Most volume and cost metrics support time ranges up to **365 days** with daily g
 - `response_cached_count` — count of responses served from cache (31-day limit)
 
 **Cost metrics** (how much money):
-- `total_usage` — total cost in USD (up to 365 days)
+- `total_usage` — total cost in USD, including BYOK inference cost (up to 365 days). Computed as `sum(usage) + sum(byok_usage_inference)` so it reflects true spend for both credits and BYOK users.
 - `byok_usage` — BYOK (bring your own key) inference cost in USD (up to 365 days)
-- `credits_usage` — credits-based usage in USD (31-day limit)
+- `credits_usage` — all charges billed to OpenRouter credits in USD, including BYOK platform fees (up to 365 days)
+- `openrouter_usage` — non-BYOK inference spend in USD; excludes requests made with user-provided keys (31-day limit)
+- `byok_fees` — BYOK platform fees in USD; the margin charged on top of BYOK inference cost (31-day limit)
 - `usage_upstream` — provider-side (upstream) cost in USD (up to 365 days)
 - `usage_cache` — cache cost component in USD (up to 365 days)
 - `usage_data` — data logging cost adjustment in USD; typically negative when a data logging discount applies (up to 365 days)
@@ -131,6 +133,8 @@ All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is w
 - `variant` — model variant (e.g., standard, extended)
 - `api_key_id` — which API key made the request
 - `user` — the creator user ID (for org-level queries)
+- `workspace` — workspace ID
+- `app` — application ID
 
 **Limited to 31-day time ranges:**
 - `generation_id` — unique ID for each generation (use to drill down to individual requests, then inspect via the `openrouter-generations` skill)
@@ -138,8 +142,6 @@ All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is w
 - `origin` — request origin/source
 - `country` — request country
 - `finish_reason` — why the generation ended (stop, length, etc.)
-- `workspace` — workspace ID
-- `app` — application ID
 - `external_user` — custom user ID passed by the caller
 - `context_length_bucket` — bucketed context length (1K, 10K, 100K, etc.)
 
@@ -191,7 +193,9 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "How can I save money?" | `total_usage`, `cache_hit_rate`, `tokens_total` | `model` | See cost optimization in `openrouter-analytics` skill |
 | "Show me individual requests" | `total_usage`, `tokens_total` | `generation_id` | 31-day limit. Use returned IDs with `openrouter-generations` skill for full metadata and content |
 | "How much BYOK spend?" | `byok_usage` | `model` | Up to 365 days |
-| "BYOK vs credits split?" | `byok_usage`, `credits_usage` | — | `credits_usage` limited to 31 days |
+| "BYOK vs credits split?" | `byok_usage`, `credits_usage` | — | Both up to 365 days |
+| "BYOK platform fees?" | `byok_fees` | `model` | 31-day limit |
+| "Non-BYOK inference spend?" | `openrouter_usage` | `model` | 31-day limit |
 | "How many guardrail triggers?" | `guardrail_invoked_count`, `guardrail_invoked_rate` | `model` | 31-day limit |
 | "How many cached responses?" | `response_cached_count`, `response_cached_rate` | `model` | 31-day limit |
 | "Where does my spend go?" | `usage_upstream`, `usage_cache`, `usage_data` | — | Full cost breakdown (up to 365 days) |
@@ -199,9 +203,35 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "File processing costs?" | `usage_file`, `usage_upstream_file` | `model` | 31-day limit |
 | "Web fetch costs?" | `usage_web_fetch`, `usage_upstream_web_fetch` | `model` | 31-day limit |
 
+## Classifier Dimensions
+
+The query builder supports dynamic dimensions backed by a classifier join table (`generation_classifications`). These allow grouping generations by custom classification labels (e.g., category, sentiment) without adding static columns to the schema.
+
+To use classifier dimensions, add the `classifier_dimensions` field to your query request:
+
+```json
+{
+  "metrics": ["request_count", "total_usage"],
+  "classifier_dimensions": {
+    "classifier_id": "my-classifier-uuid",
+    "dimension_names": ["category", "sentiment"]
+  },
+  "granularity": "day"
+}
+```
+
+- `classifier_id` (required) — the UUID of the classifier whose labels to group by
+- `dimension_names` (optional) — array of specific dimension field names within the classifier. If omitted, all dimensions for the classifier are included (max 10).
+
+Classifier dimensions are always resolved against the raw generations table (31-day time range limit) via a LEFT JOIN. They cannot be combined with materialized-view-only queries.
+
+## API Key Hash Filters
+
+When filtering by `api_key_id`, you can pass either the numeric internal ID or the 64-character SHA-256 hash exposed by the keys API. Hash values are automatically resolved to numeric IDs before querying ClickHouse. If a hash cannot be resolved, the filter uses a sentinel value that returns zero rows (no error).
+
 ## Constraints
 
-- Maximum 2 dimensions per query
+- Maximum 2 dimensions per query (plus optional classifier dimensions)
 - Maximum 20 filters per query
 - Maximum 10,000 rows returned per query (default 1,000)
 - `group_limit` (1–10,000): controls max rows per dimension combination. Auto-computed on time-series queries with dimensions to guarantee full time-window coverage. Set explicitly to cap per-group rows (e.g., top N per model per day).

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -205,7 +205,12 @@ Use this guide to translate natural-language questions into the right metric/dim
 
 ## API Key Hash Filters
 
-When filtering by `api_key_id`, you can pass either the numeric internal ID or the 64-character SHA-256 hash exposed by the keys API. Hash values are automatically resolved to numeric IDs before querying ClickHouse. If a hash cannot be resolved, the filter uses a sentinel value that returns zero rows (no error).
+When filtering by `api_key_id`, you can pass:
+
+- The **numeric ID** — found in generation metadata (the `api_key_id` field on each generation) and in label-resolved analytics query results.
+- The **64-character SHA-256 hash** — returned by `GET /api/v1/keys` as the `key_hash` field.
+
+Hash values are automatically resolved to numeric IDs before querying ClickHouse. If a hash cannot be resolved, the filter uses a sentinel value that returns zero rows (no error).
 
 ## Constraints
 

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -96,10 +96,10 @@ Latency by provider (limited to 31-day range):
 npx tsx query-analytics.ts --metrics avg_latency,p90_latency --dimensions provider --order-by p90_latency
 ```
 
-Usage cost breakdown (upstream, cache, data logging, web search):
+Usage cost breakdown (credits, BYOK, upstream, cache, data logging, web search):
 
 ```bash
-npx tsx query-analytics.ts --metrics usage_upstream,usage_cache,usage_data,usage_web --granularity day
+npx tsx query-analytics.ts --metrics credits_usage,byok_usage,byok_fees,usage_upstream,usage_cache,usage_data,usage_web --granularity day
 ```
 
 ## Common Query Templates
@@ -119,7 +119,7 @@ Returns a list of pre-built query templates for common questions, each with:
 The query endpoint returns an array of data rows. Each row is a flat object with keys matching the requested metrics and dimensions.
 
 When interpreting results for the user:
-- **Spend metrics** (`total_usage`, `usage_upstream`, `usage_cache`, `usage_web`, `usage_upstream_web`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, `usage_upstream_web_fetch`) are in USD. `usage_data` is typically negative (a data logging discount)
+- **Spend metrics** (`total_usage`, `credits_usage`, `openrouter_usage`, `byok_usage`, `byok_fees`, `usage_upstream`, `usage_cache`, `usage_web`, `usage_upstream_web`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, `usage_upstream_web_fetch`) are in USD. `total_usage` includes BYOK inference cost. `usage_data` is typically negative (a data logging discount)
 - **Token counts** (`tokens_total`, `tokens_prompt`, `tokens_completion`) are in native model tokens
 - **Latency** (`avg_latency`, `p50_latency`, etc.) is in milliseconds
 - **Rates** (`cache_hit_rate`) are 0–1 ratios
@@ -133,7 +133,7 @@ When interpreting results for the user:
 When the user asks "How can I spend less?" or similar:
 
 1. Query top models by spend: `--metrics total_usage,tokens_total,cache_hit_rate,request_count --dimensions model --order-by total_usage --limit 10`
-2. Query cost breakdown: `--metrics usage_upstream,usage_cache,usage_data,usage_web,usage_file --granularity day` to see where spend goes
+2. Query cost breakdown: `--metrics credits_usage,byok_usage,byok_fees,usage_upstream,usage_cache,usage_data,usage_web,usage_file --granularity day` to see where spend goes
 3. Look for:
    - Models with high spend but low `cache_hit_rate` — prompt caching can help
    - Expensive models that could be replaced by cheaper alternatives for specific tasks


### PR DESCRIPTION
## Summary\n\nSyncs analytics skills with 6 query builder changes merged in the last 24h.\n\n**New metrics added:**\n- `openrouter_usage` — non-BYOK inference spend (generations-only, 31-day limit)\n- `byok_fees` — BYOK platform fees (generations-only, 31-day limit)\n\n**Corrected availability:**\n- `total_usage` now includes BYOK inference cost (`sum(usage) + sum(byok_usage_inference)` in MV)\n- `credits_usage` upgraded to MV-available (365 days), was incorrectly documented as 31 days\n- `workspace` and `app` dimensions moved to \"all time ranges\" (both are in MV)\n\n**New features documented:**\n- `classifier_dimensions` request field for dynamic joined dimensions (#24668, #24645, #24702)\n- API key hash resolution in filters — 64-char SHA-256 hashes auto-resolve to numeric IDs (#24529)\n\n**Updated examples:** cost breakdown queries now reference the full set of cost metrics."

Link to Devin session: https://openrouter.devinenterprise.com/sessions/d3cf42f159d74a71bf9aa395599a7760
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->