### PR TITLE
docs(analytics): sync skills with classifier dimensions/filters and model label resolution (2026-06-19)

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -295,7 +295,7 @@ You can combine `classifier_dimensions` and `classifier_filters` in the same que
 
 | Status | Meaning | Action |
 |---|---|---|
-| 400 | Invalid query (bad metric name, too many dimensions, invalid time range, unknown classifier dimension names) | Check the meta endpoint for valid values. Verify time range start < end. Max 2 dimensions, 20 filters. |
+| 400 | Invalid query (bad metric name, too many dimensions, invalid time range, unknown classifier dimension names) | Check the meta endpoint for valid values. Verify time range start < end. Max 2 dimensions, 20 filters, 10 classifier filters. |
 | 401 | Invalid or missing API key | Check `OPENROUTER_API_KEY` is set correctly |
 | 403 | Not a management key, or classifier doesn't belong to your account | The key must be a provisioning/management key. Classifier must belong to the authenticated account. |
 | 408 | Query timed out | Narrow the time range, reduce dimensions, or add filters to scan less data |

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -268,9 +268,57 @@ Group by or filter on classifier-assigned values (e.g. categories, sentiment, in
 
 - `classifier_id` (UUID, required) — must belong to your account
 - `dimension_names` (string[], optional) — specific dimension names to group by. Max 10. Omit to include all.
-- `include_nulls` (boolean, optional) — `true` = LEFT JOIN (unclassified generations appear with null values). `false` (default) = INNER JOIN (only classified generations).
+- `include_nulls` (boolean, optional, default `false`) — controls whether generations that haven't been classified yet are included in results. See [include_nulls behavior](#include_nulls-behavior) below.
 
 With a single dimension name (e.g. `["category"]`), result rows contain `category` as a column. With multiple, rows contain `clf_dimension_name` and `clf_dimension_value` columns.
+
+#### `include_nulls` behavior
+
+By default (`include_nulls: false`), the query uses an INNER JOIN — only generations with a matching classification row are counted. Generations the classifier hasn't processed (or that don't match any of the requested `dimension_names`) are excluded entirely from metrics like `request_count` and `total_usage`.
+
+Set `include_nulls: true` to switch to a LEFT JOIN. Every generation in the time range is counted, and unclassified ones appear with empty/null classifier values.
+
+**Example — `include_nulls: false` (default):**
+
+```json
+{
+  "metrics": ["request_count"],
+  "classifier_dimensions": {
+    "classifier_id": "a1b2c3d4-...",
+    "dimension_names": ["category"]
+  }
+}
+```
+```json
+[
+  { "category": "code_generation", "request_count": "120" },
+  { "category": "summarization",   "request_count": "45" }
+]
+```
+
+Only classified generations are counted — the totals reflect the subset that the classifier has labeled.
+
+**Example — `include_nulls: true`:**
+
+```json
+{
+  "metrics": ["request_count"],
+  "classifier_dimensions": {
+    "classifier_id": "a1b2c3d4-...",
+    "dimension_names": ["category"],
+    "include_nulls": true
+  }
+}
+```
+```json
+[
+  { "category": "code_generation", "request_count": "120" },
+  { "category": "summarization",   "request_count": "45" },
+  { "category": "",                 "request_count": "300" }
+]
+```
+
+The empty `category` row captures all generations without a classification. Use this when you need the full request count to add up — for instance, to see what fraction of traffic the classifier covers.
 
 ### classifier_filters
 

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -59,9 +59,11 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `dimensions` | `string[]` | `[]` | Up to 2 dimensions to group by |
+| `classifier_dimensions` | `object` | none | Dynamic classifier-based grouping. See [Classifier Dimensions & Filters](#classifier-dimensions--filters). |
 | `granularity` | `string` | none | Time bucketing: `minute`, `hour`, `day`, `week`, `month` |
 | `time_range` | `object` | last 7 days | `{ start, end }` as ISO 8601 datetime strings |
 | `filters` | `object[]` | `[]` | Up to 20 filter conditions |
+| `classifier_filters` | `object` | none | Filter by classifier-assigned values. See [Classifier Dimensions & Filters](#classifier-dimensions--filters). |
 | `order_by` | `object` | time desc (if granularity set) | `{ field, direction }` where field is a metric, dimension, or `"date"` (short-form alias — maps to `date__day`, `date__hour`, etc. based on granularity) |
 | `limit` | `integer` | 1000 | Maximum total rows to return (1–10,000). On time-series queries with dimensions and no explicit `group_limit`, the server may raise this to accommodate the expected number of time-bucket/dimension combinations. |
 | `group_limit` | `integer` | auto-computed | Maximum rows per distinct dimension combination (ClickHouse LIMIT n BY). When omitted on time-series queries (granularity + dimensions), auto-computed from the time range to guarantee full time-window coverage per group. Explicit values override the default. Ignored when no dimensions are specified. |
@@ -121,7 +123,7 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 
 > **Numeric types:** Count metrics (`request_count`, `tokens_*`, etc.) are returned as strings (`"1523"`). Cost and rate metrics (`total_usage`, `cache_hit_rate`, latency, throughput) are returned as numbers (`4.27`). Parse count values with `Number()` or `parseInt()` before arithmetic.
 
-> **Label resolution:** Dimensions `api_key_id`, `app`, `user`, and `workspace` return human-readable labels in data rows (key names, app titles, user names, workspace names), not raw IDs.
+> **Label resolution:** Dimensions `model`, `api_key_id`, `app`, `user`, and `workspace` return human-readable labels in data rows (model display names, key names, app titles, user names, workspace names), not raw IDs.
 
 ## CLI Reference
 
@@ -157,7 +159,7 @@ The CLI prints a single JSON object to **stdout** with two keys — `data` (the 
 
 A human-readable stats line (row count, query time, truncation/cache flags) is written to **stderr** for terminal use only.
 
-> **When parsing output programmatically, always check `metadata.truncated`.** If `true`, the result was capped at `--limit` and is a *partial* dataset — increase `--limit` or paginate before reporting totals/rankings. Dimensions `api_key_id`, `user`, `app`, and `workspace` are already resolved to human-readable names in the data rows.
+> **When parsing output programmatically, always check `metadata.truncated`.** If `true`, the result was capped at `--limit` and is a *partial* dataset — increase `--limit` or paginate before reporting totals/rankings. Dimensions `model`, `api_key_id`, `user`, `app`, and `workspace` are already resolved to human-readable names in the data rows.
 
 **Multi-filter queries:** the CLI builds a multi-element `filters` array (ANDed together) from the unindexed base flag (`--filter-field`/`--filter-op`/`--filter-value`) plus the indexed `--filter-field-N`/`--filter-op-N`/`--filter-value-N` flags. Each filter must supply all three parts (field, op, value); a partial triplet is rejected. Up to **20 filters** total (the base flag plus indices 1–19), matching the API cap. Indices may be sparse (e.g. base + `-2` with `-1` omitted is fine — gaps are skipped, not silently dropped). For a query like `model = X AND provider = Y`:
 
@@ -248,13 +250,54 @@ Combine up to 2 dimensions for cross-tabulation:
 }
 ```
 
+## Classifier Dimensions & Filters
+
+Group by or filter on classifier-assigned values (e.g. categories, sentiment, intent tags). These are dynamic dimensions backed by the `generation_classifications` table. Both always force queries to the raw generations table (31-day limit).
+
+### classifier_dimensions
+
+```json
+{
+  "classifier_dimensions": {
+    "classifier_id": "<uuid>",
+    "dimension_names": ["category"],
+    "include_nulls": false
+  }
+}
+```
+
+- `classifier_id` (UUID, required) — must belong to your account
+- `dimension_names` (string[], optional) — specific dimension names to group by. Max 10. Omit to include all.
+- `include_nulls` (boolean, optional) — `true` = LEFT JOIN (unclassified generations appear with null values). `false` (default) = INNER JOIN (only classified generations).
+
+With a single dimension name (e.g. `["category"]`), result rows contain `category` as a column. With multiple, rows contain `clf_dimension_name` and `clf_dimension_value` columns.
+
+### classifier_filters
+
+```json
+{
+  "classifier_filters": {
+    "classifier_id": "<uuid>",
+    "filters": [
+      { "field": "category", "operator": "eq", "value": "code_generation" },
+      { "field": "sentiment", "operator": "in", "value": ["positive", "neutral"] }
+    ]
+  }
+}
+```
+
+- `classifier_id` (UUID, required) — must belong to your account
+- `filters` (array, required) — 1–10 filter conditions. Only equality/set operators are supported: `eq`, `neq`, `in`, `not_in`. Ordered comparison (`gt`, `lt`, etc.) is not available because classifier values are strings.
+
+You can combine `classifier_dimensions` and `classifier_filters` in the same query (they can reference different classifiers), and combine them with regular `dimensions` and `filters`.
+
 ## Error Handling
 
 | Status | Meaning | Action |
 |---|---|---|
-| 400 | Invalid query (bad metric name, too many dimensions, invalid time range) | Check the meta endpoint for valid values. Verify time range start < end. Max 2 dimensions, 20 filters. |
+| 400 | Invalid query (bad metric name, too many dimensions, invalid time range, unknown classifier dimension names) | Check the meta endpoint for valid values. Verify time range start < end. Max 2 dimensions, 20 filters. |
 | 401 | Invalid or missing API key | Check `OPENROUTER_API_KEY` is set correctly |
-| 403 | Not a management key | The key must be a provisioning/management key. Create one at openrouter.ai/settings/management-keys |
+| 403 | Not a management key, or classifier doesn't belong to your account | The key must be a provisioning/management key. Classifier must belong to the authenticated account. |
 | 408 | Query timed out | Narrow the time range, reduce dimensions, or add filters to scan less data |
 | 429 | Rate limited (64 RPM) | Wait and retry |
 | 500 | Server error | Retry after a moment |
@@ -264,6 +307,8 @@ Combine up to 2 dimensions for cross-tabulation:
 Some metric/dimension combinations support time ranges up to **365 days** (with daily granularity), while others are limited to **31 days**. The server resolves this automatically based on the requested metrics and dimensions.
 
 Usage breakdown metrics follow the same pattern: `credits_usage`, `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, and `usage_upstream_web` support up to 365 days, while `openrouter_usage`, `byok_fees`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, and `usage_upstream_web_fetch` are limited to 31 days.
+
+Classifier dimensions and classifier filters always force the query to the raw generations table, so the 31-day limit applies regardless of which metrics are requested.
 
 If a query times out, try:
 - Narrowing the time range

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -123,7 +123,7 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 
 > **Numeric types:** Count metrics (`request_count`, `tokens_*`, etc.) are returned as strings (`"1523"`). Cost and rate metrics (`total_usage`, `cache_hit_rate`, latency, throughput) are returned as numbers (`4.27`). Parse count values with `Number()` or `parseInt()` before arithmetic.
 
-> **Label resolution:** Dimensions `model`, `api_key_id`, `app`, `user`, and `workspace` return human-readable labels in data rows (model display names, key names, app titles, user names, workspace names), not raw IDs.
+> **Label resolution:** Dimensions `api_key_id`, `app`, `user`, and `workspace` return human-readable labels in data rows (key names, app titles, user names, workspace names), not raw IDs.
 
 ## CLI Reference
 
@@ -159,7 +159,7 @@ The CLI prints a single JSON object to **stdout** with two keys — `data` (the 
 
 A human-readable stats line (row count, query time, truncation/cache flags) is written to **stderr** for terminal use only.
 
-> **When parsing output programmatically, always check `metadata.truncated`.** If `true`, the result was capped at `--limit` and is a *partial* dataset — increase `--limit` or paginate before reporting totals/rankings. Dimensions `model`, `api_key_id`, `user`, `app`, and `workspace` are already resolved to human-readable names in the data rows.
+> **When parsing output programmatically, always check `metadata.truncated`.** If `true`, the result was capped at `--limit` and is a *partial* dataset — increase `--limit` or paginate before reporting totals/rankings. Dimensions `api_key_id`, `user`, `app`, and `workspace` are already resolved to human-readable names in the data rows.
 
 **Multi-filter queries:** the CLI builds a multi-element `filters` array (ANDed together) from the unindexed base flag (`--filter-field`/`--filter-op`/`--filter-value`) plus the indexed `--filter-field-N`/`--filter-op-N`/`--filter-value-N` flags. Each filter must supply all three parts (field, op, value); a partial triplet is rejected. Up to **20 filters** total (the base flag plus indices 1–19), matching the API cap. Indices may be sparse (e.g. base + `-2` with `-1` omitted is fine — gaps are skipped, not silently dropped). For a query like `model = X AND provider = Y`:
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -117,13 +117,12 @@ Some dimensions have their raw IDs automatically resolved to human-readable labe
 
 | Dimension | Resolved to |
 |---|---|
-| `model` | Formatted model display name (e.g. `openai/gpt-4o` → `GPT-4o`) |
 | `api_key_id` | Key name/label |
 | `app` | App title or origin URL |
 | `user` | User name or email address |
 | `workspace` | Workspace name |
 
-All other dimensions (e.g., `provider`, `country`, `origin`) are returned as-is without resolution.
+All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is without resolution.
 
 > Rows with an empty `user` value represent traffic not attributed to a specific org member (e.g., API keys created at the org level).
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -242,9 +242,11 @@ Add a `classifier_dimensions` object to the query request to group by classifier
 |---|---|---|
 | `classifier_id` | UUID (required) | The classifier to use. Must belong to your account. |
 | `dimension_names` | string[] (optional) | Specific dimension names to include. Omit to include all. Max 10. |
-| `include_nulls` | boolean (optional) | When `true`, unclassified generations appear with null values (LEFT JOIN). Default `false` (INNER JOIN — only classified generations). |
+| `include_nulls` | boolean (optional) | Default `false`. Controls whether unclassified generations appear in results. See below. |
 
 When a single `dimension_names` entry is provided (e.g. `["category"]`), result rows contain `category` as a column. With multiple names, rows contain `clf_dimension_name` and `clf_dimension_value` columns.
+
+**`include_nulls` behavior:** With `false` (default), only generations that have a classification row are included — the query uses an INNER JOIN, so unclassified generations are excluded from all metric totals. With `true`, the query uses a LEFT JOIN — every generation is counted, and those without a classification appear with an empty string as the dimension value. Set `true` when you need totals to match your overall traffic (e.g. to compute what percentage of requests the classifier covers).
 
 ### Classifier Filters
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -117,12 +117,13 @@ Some dimensions have their raw IDs automatically resolved to human-readable labe
 
 | Dimension | Resolved to |
 |---|---|
+| `model` | Formatted model display name (e.g. `openai/gpt-4o` → `GPT-4o`) |
 | `api_key_id` | Key name/label |
 | `app` | App title or origin URL |
 | `user` | User name or email address |
 | `workspace` | Workspace name |
 
-All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is without resolution.
+All other dimensions (e.g., `provider`, `country`, `origin`) are returned as-is without resolution.
 
 > Rows with an empty `user` value represent traffic not attributed to a specific org member (e.g., API keys created at the org level).
 
@@ -217,13 +218,65 @@ Several dimensions are **label-resolved** in query results — the response show
 
 Other dimensions (`provider`, `origin`, `country`, `finish_reason`, `external_user`, etc.) are not enriched — filter values match what's returned in results.
 
+## Classifier Dimensions & Filters
+
+The query builder supports **classifier dimensions** and **classifier filters** for grouping and filtering by user-defined classification labels (e.g. categories, sentiment, intent tags assigned to generations by a classifier).
+
+These are dynamic dimensions backed by the `generation_classifications` table via a JOIN, so they always query the raw generations table (31-day limit).
+
+### Classifier Dimensions
+
+Add a `classifier_dimensions` object to the query request to group by classifier-assigned values:
+
+```json
+{
+  "classifier_dimensions": {
+    "classifier_id": "<uuid>",
+    "dimension_names": ["category", "sentiment"],
+    "include_nulls": false
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `classifier_id` | UUID (required) | The classifier to use. Must belong to your account. |
+| `dimension_names` | string[] (optional) | Specific dimension names to include. Omit to include all. Max 10. |
+| `include_nulls` | boolean (optional) | When `true`, unclassified generations appear with null values (LEFT JOIN). Default `false` (INNER JOIN — only classified generations). |
+
+When a single `dimension_names` entry is provided (e.g. `["category"]`), result rows contain `category` as a column. With multiple names, rows contain `clf_dimension_name` and `clf_dimension_value` columns.
+
+### Classifier Filters
+
+Add a `classifier_filters` object to filter by classifier-assigned values:
+
+```json
+{
+  "classifier_filters": {
+    "classifier_id": "<uuid>",
+    "filters": [
+      { "field": "category", "operator": "eq", "value": "code_generation" }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `classifier_id` | UUID (required) | The classifier to use. Must belong to your account. |
+| `filters` | array (required) | 1–10 filter conditions on classifier dimension values. |
+
+Classifier filters only support equality/set operators: `eq`, `neq`, `in`, `not_in`. Ordered comparison (`gt`, `lt`, etc.) is not supported because classifier values are strings.
+
 ## Constraints
 
-- Maximum 2 dimensions per query
-- Maximum 20 filters per query
+- Maximum 2 dimensions per query (classifier dimensions are separate and don't count toward this limit)
+- Maximum 20 filters per query (classifier filters are separate)
+- Maximum 10 classifier filters per query
 - Maximum 10,000 rows returned per query (default 1,000)
 - `group_limit` (1–10,000): controls max rows per dimension combination. Auto-computed on time-series queries with dimensions to guarantee full time-window coverage. Set explicitly to cap per-group rows (e.g., top N per model per day).
 - Most volume/cost metrics: up to 365 days with daily granularity
 - Latency/throughput metrics and per-generation dimensions: up to 31 days
+- Classifier dimensions and classifier filters always query raw generations (31-day limit)
 - Minute granularity: only available when the time window is ≤ 3 hours
 - Rate-limited to 64 requests per minute

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -27,6 +27,7 @@ cd <skill-path>/scripts && npm install
 | Know what data is available | Run `discover-schema.ts` to see metrics, dimensions, and filters |
 | See spend / usage / volume | Run `query-analytics.ts` with appropriate metrics |
 | Break down by model, provider, API key | Add `--dimensions` to the query |
+| Break down by classifier labels | Add `classifier_dimensions` via curl (CLI flags not yet available). Set `include_nulls: true` to include unclassified generations |
 | See trends over time | Add `--granularity day` (or `hour`, `week`, `month`) |
 | Reduce costs | Run `suggest-queries.ts`, find the cost optimization template, execute it |
 | Inspect individual generations | Add `--dimensions generation_id`, then use the `openrouter-generations` skill for details |
@@ -105,6 +106,25 @@ curl -X POST https://openrouter.ai/api/v1/analytics/query \
     "granularity": "day"
   }'
 ```
+
+Same query but including unclassified generations (to see full traffic):
+
+```bash
+curl -X POST https://openrouter.ai/api/v1/analytics/query \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metrics": ["total_usage", "request_count"],
+    "classifier_dimensions": {
+      "classifier_id": "<your-classifier-uuid>",
+      "dimension_names": ["category"],
+      "include_nulls": true
+    },
+    "granularity": "day"
+  }'
+```
+
+With `include_nulls: true`, rows for unclassified generations appear with an empty `category` value. Without it (default), only classified generations are counted.
 
 Latency by provider (limited to 31-day range):
 

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -90,6 +90,22 @@ Usage by API key:
 npx tsx query-analytics.ts --metrics request_count,tokens_total --dimensions api_key_id --order-by request_count --limit 10
 ```
 
+Spend by classifier category (requires a classifier; see `openrouter-analytics-query` skill for full reference):
+
+```bash
+curl -X POST https://openrouter.ai/api/v1/analytics/query \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metrics": ["total_usage", "request_count"],
+    "classifier_dimensions": {
+      "classifier_id": "<your-classifier-uuid>",
+      "dimension_names": ["category"]
+    },
+    "granularity": "day"
+  }'
+```
+
 Latency by provider (limited to 31-day range):
 
 ```bash
@@ -125,7 +141,7 @@ When interpreting results for the user:
 - **Rates** (`cache_hit_rate`) are 0–1 ratios
 - **Throughput** (`avg_throughput`) is tokens per second
 - When `granularity` is set, rows include a `date__<granularity>` field for the time bucket (e.g., `date__day`, `date__hour`, `date__month`)
-- **Label resolution**: dimensions `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (key name, app title, user name, workspace name) directly in the data rows
+- **Label resolution**: dimensions `model`, `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (model display name, key name, app title, user name, workspace name) directly in the data rows
 - **Truncation**: when consuming output programmatically, check `metadata.truncated`. If `true`, the result was capped at `--limit` and is a *partial* dataset — raise `--limit` or paginate before reporting totals or rankings
 
 ### Cost Optimization Guidance

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -161,7 +161,7 @@ When interpreting results for the user:
 - **Rates** (`cache_hit_rate`) are 0–1 ratios
 - **Throughput** (`avg_throughput`) is tokens per second
 - When `granularity` is set, rows include a `date__<granularity>` field for the time bucket (e.g., `date__day`, `date__hour`, `date__month`)
-- **Label resolution**: dimensions `model`, `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (model display name, key name, app title, user name, workspace name) directly in the data rows
+- **Label resolution**: dimensions `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (key name, app title, user name, workspace name) directly in the data rows
 - **Truncation**: when consuming output programmatically, check `metadata.truncated`. If `true`, the result was capped at `--limit` and is a *partial* dataset — raise `--limit` or paginate before reporting totals or rankings
 
 ### Cost Optimization Guidance


### PR DESCRIPTION
## Summary

Syncs analytics skills with query builder changes from the last 24h (PRs #24955, #24962, #25181 in openrouter-web).

**New features documented:**

- `classifier_dimensions` — dynamic grouping by classifier-assigned values (category, sentiment, etc.). Accepts `classifier_id`, `dimension_names`, and `include_nulls`. Single dimension name → column alias; multiple → `clf_dimension_name`/`clf_dimension_value` columns.
- `classifier_filters` — filter by classifier values. Only supports `eq`/`neq`/`in`/`not_in` (classifier values are strings, so ordered comparison isn't meaningful). Max 10 filters.
- Both force queries to raw generations table (31-day limit).
- `include_nulls` behavior documented: `true` = LEFT JOIN (unclassified generations appear with null values), `false` (default) = INNER JOIN.
- Updated constraints section with classifier-specific limits.
- Added classifier example to main analytics skill.

**Note:** An earlier commit incorrectly added `model` to the label-resolved dimensions list. The public `/analytics/query` route intentionally excludes model from label resolution (`dimensions.filter(d => d !== 'model')`) — permaslugs are the stable public identifier. This was reverted in 90f3b99.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/0a08aef52c5a4e1f801ccaf36ffb41dd
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->