### PR TITLE
docs(analytics): expand include_nulls parameter documentation

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -268,9 +268,57 @@ Group by or filter on classifier-assigned values (e.g. categories, sentiment, in
 
 - `classifier_id` (UUID, required) — must belong to your account
 - `dimension_names` (string[], optional) — specific dimension names to group by. Max 10. Omit to include all.
-- `include_nulls` (boolean, optional) — `true` = LEFT JOIN (unclassified generations appear with null values). `false` (default) = INNER JOIN (only classified generations).
+- `include_nulls` (boolean, optional, default `false`) — controls whether generations that haven't been classified yet are included in results. See [include_nulls behavior](#include_nulls-behavior) below.
 
 With a single dimension name (e.g. `["category"]`), result rows contain `category` as a column. With multiple, rows contain `clf_dimension_name` and `clf_dimension_value` columns.
+
+#### `include_nulls` behavior
+
+By default (`include_nulls: false`), the query uses an INNER JOIN — only generations with a matching classification row are counted. Generations the classifier hasn't processed (or that don't match any of the requested `dimension_names`) are excluded entirely from metrics like `request_count` and `total_usage`.
+
+Set `include_nulls: true` to switch to a LEFT JOIN. Every generation in the time range is counted, and unclassified ones appear with empty/null classifier values.
+
+**Example — `include_nulls: false` (default):**
+
+```json
+{
+  "metrics": ["request_count"],
+  "classifier_dimensions": {
+    "classifier_id": "a1b2c3d4-...",
+    "dimension_names": ["category"]
+  }
+}
+```
+```json
+[
+  { "category": "code_generation", "request_count": "120" },
+  { "category": "summarization",   "request_count": "45" }
+]
+```
+
+Only classified generations are counted — the totals reflect the subset that the classifier has labeled.
+
+**Example — `include_nulls: true`:**
+
+```json
+{
+  "metrics": ["request_count"],
+  "classifier_dimensions": {
+    "classifier_id": "a1b2c3d4-...",
+    "dimension_names": ["category"],
+    "include_nulls": true
+  }
+}
+```
+```json
+[
+  { "category": "code_generation", "request_count": "120" },
+  { "category": "summarization",   "request_count": "45" },
+  { "category": "",                 "request_count": "300" }
+]
+```
+
+The empty `category` row captures all generations without a classification. Use this when you need the full request count to add up — for instance, to see what fraction of traffic the classifier covers.
 
 ### classifier_filters
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -242,9 +242,11 @@ Add a `classifier_dimensions` object to the query request to group by classifier
 |---|---|---|
 | `classifier_id` | UUID (required) | The classifier to use. Must belong to your account. |
 | `dimension_names` | string[] (optional) | Specific dimension names to include. Omit to include all. Max 10. |
-| `include_nulls` | boolean (optional) | When `true`, unclassified generations appear with null values (LEFT JOIN). Default `false` (INNER JOIN — only classified generations). |
+| `include_nulls` | boolean (optional) | Default `false`. Controls whether unclassified generations appear in results. See below. |
 
 When a single `dimension_names` entry is provided (e.g. `["category"]`), result rows contain `category` as a column. With multiple names, rows contain `clf_dimension_name` and `clf_dimension_value` columns.
+
+**`include_nulls` behavior:** With `false` (default), only generations that have a classification row are included — the query uses an INNER JOIN, so unclassified generations are excluded from all metric totals. With `true`, the query uses a LEFT JOIN — every generation is counted, and those without a classification appear with an empty string as the dimension value. Set `true` when you need totals to match your overall traffic (e.g. to compute what percentage of requests the classifier covers).
 
 ### Classifier Filters
 

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -27,6 +27,7 @@ cd <skill-path>/scripts && npm install
 | Know what data is available | Run `discover-schema.ts` to see metrics, dimensions, and filters |
 | See spend / usage / volume | Run `query-analytics.ts` with appropriate metrics |
 | Break down by model, provider, API key | Add `--dimensions` to the query |
+| Break down by classifier labels | Add `classifier_dimensions` via curl (CLI flags not yet available). Set `include_nulls: true` to include unclassified generations |
 | See trends over time | Add `--granularity day` (or `hour`, `week`, `month`) |
 | Reduce costs | Run `suggest-queries.ts`, find the cost optimization template, execute it |
 | Inspect individual generations | Add `--dimensions generation_id`, then use the `openrouter-generations` skill for details |
@@ -105,6 +106,25 @@ curl -X POST https://openrouter.ai/api/v1/analytics/query \
     "granularity": "day"
   }'
 ```
+
+Same query but including unclassified generations (to see full traffic):
+
+```bash
+curl -X POST https://openrouter.ai/api/v1/analytics/query \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metrics": ["total_usage", "request_count"],
+    "classifier_dimensions": {
+      "classifier_id": "<your-classifier-uuid>",
+      "dimension_names": ["category"],
+      "include_nulls": true
+    },
+    "granularity": "day"
+  }'
+```
+
+With `include_nulls: true`, rows for unclassified generations appear with an empty `category` value. Without it (default), only classified generations are counted.
 
 Latency by provider (limited to 31-day range):
 


### PR DESCRIPTION
## Summary

Expands the `include_nulls` documentation across all three analytics skills. PR #56 introduced the parameter with a one-liner; this adds behavioral explanation, example request/response pairs showing the difference between `false` (INNER JOIN, only classified generations) and `true` (LEFT JOIN, unclassified generations appear with empty values), and guidance on when to use each mode.

**openrouter-analytics-query** — new `#### include_nulls behavior` subsection with side-by-side request/response examples contrasting `false` vs `true`.

**openrouter-analytics-schema** — expanded table cell + inline paragraph explaining the JOIN semantics and when to set `true`.

**openrouter-analytics** — added decision tree entry for classifier label breakdowns, plus a second curl example showing `include_nulls: true` alongside the existing classifier example.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/e3c044c86f614fefabf144e6de35216d
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->