### PR TITLE
docs(analytics): document classifier dimensions and filters (2026-06-20)

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -65,6 +65,8 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 | `order_by` | `object` | time desc (if granularity set) | `{ field, direction }` where field is a metric, dimension, or `"date"` (short-form alias — maps to `date__day`, `date__hour`, etc. based on granularity) |
 | `limit` | `integer` | 1000 | Maximum total rows to return (1–10,000). On time-series queries with dimensions and no explicit `group_limit`, the server may raise this to accommodate the expected number of time-bucket/dimension combinations. |
 | `group_limit` | `integer` | auto-computed | Maximum rows per distinct dimension combination (ClickHouse LIMIT n BY). When omitted on time-series queries (granularity + dimensions), auto-computed from the time range to guarantee full time-window coverage per group. Explicit values override the default. Ignored when no dimensions are specified. |
+| `classifier_dimensions` | `object` | none | Group by dynamic classifier dimensions. See [Classifier Dimensions and Filters](#classifier-dimensions-and-filters) below. |
+| `classifier_filters` | `object` | none | Filter by classifier dimension values. See [Classifier Dimensions and Filters](#classifier-dimensions-and-filters) below. |
 
 ### Filter Object Shape
 
@@ -118,6 +120,7 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 | `data.metadata.row_count` | Number of rows returned |
 | `data.metadata.truncated` | `true` if results were truncated at the limit |
 | `data.cachedAt` | Unix timestamp (ms) when the result was cached. Present when the response was served from cache |
+| `data.warnings` | Optional array of strings about filter resolution issues (e.g. an `api_key_id` hash that couldn't be resolved). The query still runs; these inform the caller that some filter values may not have matched. |
 
 > **Numeric types:** Count metrics (`request_count`, `tokens_*`, etc.) are returned as strings (`"1523"`). Cost and rate metrics (`total_usage`, `cache_hit_rate`, latency, throughput) are returned as numbers (`4.27`). Parse count values with `Number()` or `parseInt()` before arithmetic.
 
@@ -247,6 +250,55 @@ Combine up to 2 dimensions for cross-tabulation:
   "limit": 20
 }
 ```
+
+## Classifier Dimensions and Filters
+
+Classifier dimensions let you group and filter analytics by custom tags applied to your generations via classifiers. A classifier is a set of named dimensions (e.g. `category`, `sentiment`) whose values are stored per-generation in a separate table.
+
+### `classifier_dimensions` object
+
+```json
+{
+  "classifier_dimensions": {
+    "classifier_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "dimension_names": ["category"],
+    "include_nulls": false
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `classifier_id` | `string` (UUID) | yes | The classifier to query against. Must belong to the caller's account. |
+| `dimension_names` | `string[]` | no | Specific dimension names to group by (max 10). If omitted, all configured dimensions are included. When exactly one name is given, the result column uses that name directly (e.g. `"category": "billing"`). With multiple names, results use generic `clf_dimension_name` / `clf_dimension_value` columns. |
+| `include_nulls` | `boolean` | no | When `true`, unclassified generations appear in results with null classifier values (LEFT JOIN). When `false` (default), only classified generations are included (INNER JOIN). |
+
+### `classifier_filters` object
+
+```json
+{
+  "classifier_filters": {
+    "classifier_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "filters": [
+      { "field": "category", "operator": "eq", "value": "billing" }
+    ]
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `classifier_id` | `string` (UUID) | yes | The classifier to filter against. Must belong to the caller's account. |
+| `filters` | `object[]` | yes | 1–10 filter conditions. Each has `field` (dimension name), `operator`, and `value`. |
+
+Classifier filter operators are limited to `eq`, `neq`, `in`, and `not_in` — ordered comparisons (`gt`, `lt`, etc.) are not supported because classifier values are strings.
+
+### Constraints
+
+- Classifier dimensions and filters force the query to use the raw generations table (31-day time range limit).
+- `classifier_dimensions` and `classifier_filters` can reference different classifiers (each has its own `classifier_id`).
+- Dimension names must match what's configured on the classifier. Invalid names return a 400 error.
+- Classifier dimension names cannot collide with built-in metric or dimension names.
 
 ## Error Handling
 

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -289,7 +289,7 @@ Classifier dimensions let you group and filter analytics by custom tags applied 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `classifier_id` | `string` (UUID) | yes | The classifier to filter against. Must belong to the caller's account. |
-| `filters` | `object[]` | yes | 1–10 filter conditions. Each has `field` (dimension name), `operator`, and `value`. |
+| `filters` | `object[]` | yes | 1–10 filter conditions. Each has `field` (dimension name), `operator` (`eq`/`neq`/`in`/`not_in`), and `value` (string for scalar operators, array of strings for `in`/`not_in`). |
 
 Classifier filter operators are limited to `eq`, `neq`, `in`, and `not_in` — ordered comparisons (`gt`, `lt`, etc.) are not supported because classifier values are strings.
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -145,6 +145,18 @@ All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is w
 - `external_user` — custom user ID passed by the caller
 - `context_length_bucket` — bucketed context length (1K, 10K, 100K, etc.)
 
+## Classifier Dimensions
+
+Beyond the built-in dimensions above, the query endpoint supports **classifier dimensions** — dynamic, user-defined groupings backed by a `generation_classifications` table. Classifiers tag individual generations with key/value pairs (e.g. `category=billing`, `sentiment=positive`).
+
+Classifier dimensions are only available on the raw generations table (31-day time range limit). See the `openrouter-analytics-query` skill for the full `classifier_dimensions` and `classifier_filters` request field reference.
+
+Key points:
+- Each classifier is identified by a UUID and must belong to the caller's account
+- Dimension names are freeform identifiers matching `/^[a-zA-Z_][a-zA-Z0-9_]{0,63}$/`
+- Classifier filters only support `eq`, `neq`, `in`, `not_in` (no ordered comparisons — values are strings)
+- Classifier dimensions cannot collide with built-in metric or dimension names
+
 ## Understanding Operators
 
 Filter operators for the `filters` array in query requests:
@@ -202,6 +214,7 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "Web search costs?" | `usage_web`, `usage_upstream_web` | `model` | Up to 365 days |
 | "File processing costs?" | `usage_file`, `usage_upstream_file` | `model` | 31-day limit |
 | "Web fetch costs?" | `usage_web_fetch`, `usage_upstream_web_fetch` | `model` | 31-day limit |
+| "Spend by classifier tag?" | `total_usage` | — | Use `classifier_dimensions` with the classifier UUID and dimension name. 31-day limit |
 
 ## Filter Value Reference
 
@@ -227,3 +240,5 @@ Other dimensions (`provider`, `origin`, `country`, `finish_reason`, `external_us
 - Latency/throughput metrics and per-generation dimensions: up to 31 days
 - Minute granularity: only available when the time window is ≤ 3 hours
 - Rate-limited to 64 requests per minute
+- Classifier dimensions: max 10 dimension names, max 10 classifier filters
+- Classifier dimensions/filters force the generations table (31-day limit)

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -30,6 +30,7 @@ cd <skill-path>/scripts && npm install
 | See trends over time | Add `--granularity day` (or `hour`, `week`, `month`) |
 | Reduce costs | Run `suggest-queries.ts`, find the cost optimization template, execute it |
 | Inspect individual generations | Add `--dimensions generation_id`, then use the `openrouter-generations` skill for details |
+| Break down by classifier tags | Use `classifier_dimensions` / `classifier_filters` in the JSON body (see `openrouter-analytics-query` skill). 31-day limit. |
 | Answer a specific question | Map the question → metrics + dimensions, then query |
 
 ## Workflow


### PR DESCRIPTION
## Summary

Syncs analytics skills with the classifier dimensions/filters feature wired up in openrouter-web PRs [#24962](https://github.com/OpenRouterTeam/openrouter-web/pull/24962) and [#25181](https://github.com/OpenRouterTeam/openrouter-web/pull/25181) since the last sync on 2026-06-17.

The previous sync (PR #55) explicitly removed classifier docs because the API layer wasn't wired up yet. It now is — the `/analytics/query` endpoint accepts `classifier_dimensions` and `classifier_filters` in the request body.

**Changes across three skill files:**

- **openrouter-analytics-query**: Add `classifier_dimensions` and `classifier_filters` to the optional fields table. Add a full "Classifier Dimensions and Filters" section documenting both request objects, field schemas, operator restrictions (`eq`/`neq`/`in`/`not_in` only — values are strings), and constraints (forces generations table, 31-day limit). Also document the response `data.warnings` field for filter resolution issues.
- **openrouter-analytics-schema**: Add a "Classifier Dimensions" section between dimension categories and operators. Add classifier constraints to the constraints list. Add a "Spend by classifier tag?" row to the question-mapping table.
- **openrouter-analytics**: Add a "Break down by classifier tags" row to the decision tree.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/d44ad090723d4489b53cccda41e95854
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->