### PR TITLE
docs(analytics): add classifier dimensions/filters and response warnings to skills

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -66,6 +66,54 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 | `limit` | `integer` | 1000 | Maximum total rows to return (1–10,000). On time-series queries with dimensions and no explicit `group_limit`, the server may raise this to accommodate the expected number of time-bucket/dimension combinations. |
 | `group_limit` | `integer` | auto-computed | Maximum rows per distinct dimension combination (ClickHouse LIMIT n BY). When omitted on time-series queries (granularity + dimensions), auto-computed from the time range to guarantee full time-window coverage per group. Explicit values override the default. Ignored when no dimensions are specified. |
 
+### Classifier Dimensions
+
+Classifier dimensions let you group results by dynamic, user-defined classification fields (e.g., "category", "sentiment") stored in the `generation_classifications` table. They require a classifier configured at [openrouter.ai/activity](https://openrouter.ai/activity).
+
+```json
+{
+  "metrics": ["request_count", "total_usage"],
+  "classifier_dimensions": {
+    "classifier_id": "<uuid>",
+    "dimension_names": ["category", "sentiment"],
+    "include_nulls": false
+  },
+  "granularity": "day"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `classifier_id` | `string` (UUID) | The classifier to join against. Must belong to the caller's account. |
+| `dimension_names` | `string[]` | Up to 10 dimension field names configured on the classifier. Omit to group by all configured dimensions. |
+| `include_nulls` | `boolean` | Whether to include generations that have no classification for this classifier. Defaults to `false`. |
+
+Classifier dimensions force the query to the raw generations table (31-day limit), since they require a LEFT JOIN against `generation_classifications`.
+
+### Classifier Filters
+
+Filter by classifier-assigned values independently of grouping. Requires the same classifier ownership check.
+
+```json
+{
+  "metrics": ["request_count"],
+  "classifier_filters": {
+    "classifier_id": "<uuid>",
+    "filters": [
+      { "field": "category", "operator": "eq", "value": "support" },
+      { "field": "sentiment", "operator": "in", "value": ["positive", "neutral"] }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `classifier_id` | `string` (UUID) | The classifier whose values to filter on. |
+| `filters` | `object[]` | 1–10 filter conditions on classifier dimension fields. Only `eq`, `neq`, `in`, `not_in` operators are supported (no ordered comparison — the underlying column is String). |
+
+Classifier filters also force the generations table (31-day limit). You can combine `classifier_dimensions` and `classifier_filters` in the same query (they must reference the same `classifier_id`).
+
 ### Filter Object Shape
 
 ```json
@@ -104,7 +152,8 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
       "row_count": 2,
       "truncated": false
     },
-    "cachedAt": 1747699200000
+    "cachedAt": 1747699200000,
+    "warnings": ["Could not resolve api_key_id hash: abc123..."]
   }
 }
 ```
@@ -118,6 +167,7 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 | `data.metadata.row_count` | Number of rows returned |
 | `data.metadata.truncated` | `true` if results were truncated at the limit |
 | `data.cachedAt` | Unix timestamp (ms) when the result was cached. Present when the response was served from cache |
+| `data.warnings` | Optional array of warning strings (e.g., unresolvable `api_key_id` hashes). The query still runs; these are informational |
 
 > **Numeric types:** Count metrics (`request_count`, `tokens_*`, etc.) are returned as strings (`"1523"`). Cost and rate metrics (`total_usage`, `cache_hit_rate`, latency, throughput) are returned as numbers (`4.27`). Parse count values with `Number()` or `parseInt()` before arithmetic.
 

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -202,6 +202,17 @@ Use this guide to translate natural-language questions into the right metric/dim
 | "Web search costs?" | `usage_web`, `usage_upstream_web` | `model` | Up to 365 days |
 | "File processing costs?" | `usage_file`, `usage_upstream_file` | `model` | 31-day limit |
 | "Web fetch costs?" | `usage_web_fetch`, `usage_upstream_web_fetch` | `model` | 31-day limit |
+| "Break down by custom category?" | any metric | use `classifier_dimensions` | Requires a classifier; 31-day limit. See `openrouter-analytics-query` skill. |
+| "Filter to a classification?" | any metric | use `classifier_filters` | Requires a classifier; 31-day limit. See `openrouter-analytics-query` skill. |
+
+## Classifier Dimensions & Filters
+
+The analytics API supports dynamic, user-defined dimensions and filters backed by classifiers. Classifiers tag generations with custom fields (e.g., "category", "sentiment") and store them in the `generation_classifications` ClickHouse table.
+
+- **`classifier_dimensions`** — group query results by classifier field values. Accepts a `classifier_id` (UUID), optional `dimension_names` (up to 10), and `include_nulls` flag.
+- **`classifier_filters`** — filter results by classifier field values without grouping. Accepts a `classifier_id` and 1–10 filters using only `eq`, `neq`, `in`, `not_in` operators.
+
+Both force the query to the raw generations table (31-day time range limit). See the `openrouter-analytics-query` skill for the full request schema and examples.
 
 ## Filter Value Reference
 
@@ -219,11 +230,12 @@ Other dimensions (`provider`, `origin`, `country`, `finish_reason`, `external_us
 
 ## Constraints
 
-- Maximum 2 dimensions per query
-- Maximum 20 filters per query
+- Maximum 2 dimensions per query (plus up to 10 classifier dimensions)
+- Maximum 20 filters per query (plus up to 10 classifier filters)
 - Maximum 10,000 rows returned per query (default 1,000)
 - `group_limit` (1–10,000): controls max rows per dimension combination. Auto-computed on time-series queries with dimensions to guarantee full time-window coverage. Set explicitly to cap per-group rows (e.g., top N per model per day).
 - Most volume/cost metrics: up to 365 days with daily granularity
 - Latency/throughput metrics and per-generation dimensions: up to 31 days
+- Classifier dimensions/filters: always 31 days (forced to generations table)
 - Minute granularity: only available when the time window is ≤ 3 hours
 - Rate-limited to 64 requests per minute

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -102,6 +102,22 @@ Usage cost breakdown (credits, BYOK, upstream, cache, data logging, web search):
 npx tsx query-analytics.ts --metrics credits_usage,byok_usage,byok_fees,usage_upstream,usage_cache,usage_data,usage_web --granularity day
 ```
 
+Break down by classifier dimension (requires a classifier configured at openrouter.ai/activity):
+
+```bash
+curl -X POST https://openrouter.ai/api/v1/analytics/query \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metrics": ["request_count", "total_usage"],
+    "classifier_dimensions": {
+      "classifier_id": "<uuid>",
+      "dimension_names": ["category"]
+    },
+    "granularity": "day"
+  }'
+```
+
 ## Common Query Templates
 
 ```bash
@@ -126,6 +142,7 @@ When interpreting results for the user:
 - **Throughput** (`avg_throughput`) is tokens per second
 - When `granularity` is set, rows include a `date__<granularity>` field for the time bucket (e.g., `date__day`, `date__hour`, `date__month`)
 - **Label resolution**: dimensions `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (key name, app title, user name, workspace name) directly in the data rows
+- **Warnings**: the response may include an optional `warnings` array (e.g., when an `api_key_id` hash filter couldn't be resolved). The query still executes normally; warnings are informational.
 - **Truncation**: when consuming output programmatically, check `metadata.truncated`. If `true`, the result was capped at `--limit` and is a *partial* dataset — raise `--limit` or paginate before reporting totals or rankings
 
 ### Cost Optimization Guidance


### PR DESCRIPTION
## Summary

Syncs analytics skills with query builder changes from Jun 17–19 (PRs #24645, #24668, #24702, #24888, #24955, #24962, #25181). The query builder now supports `classifier_dimensions` and `classifier_filters` in `AnalyticsQueryRequestSchema`, and the public API response includes an optional `warnings` array. None of this was documented in the skills.

Changes across three skill files:

- **openrouter-analytics-query/SKILL.md** — New "Classifier Dimensions" and "Classifier Filters" sections with full request schema, field tables, operator restrictions (`eq`/`neq`/`in`/`not_in` only), and 31-day forced-generations-table note. Added `data.warnings` to response fields table and example JSON.
- **openrouter-analytics-schema/SKILL.md** — New "Classifier Dimensions & Filters" overview section, two question-mapping rows, updated constraints list to call out classifier limits separately.
- **openrouter-analytics/SKILL.md** — Curl example for classifier dimension queries, `warnings` field in interpreting results.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/8df3038e121b456db19994a70ae82b49
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->