### PR TITLE
docs(analytics): add classifier dimensions/filters and response warnings

### DIFF
--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -105,7 +105,7 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 
 ## Classifier Dimensions
 
-Classifier dimensions allow grouping by dynamic, user-defined classification labels (e.g., topic, sentiment, category) produced by a classifier attached to your account. They join the `generation_classifications` table.
+Classifier dimensions allow grouping by dynamic, user-defined classification labels (e.g., topic, sentiment, category) produced by a classifier attached to your account.
 
 ```json
 {
@@ -121,10 +121,10 @@ Classifier dimensions allow grouping by dynamic, user-defined classification lab
 |---|---|---|---|
 | `classifier_id` | `string` (UUID) | Yes | ID of the classifier (must belong to the caller's account) |
 | `dimension_names` | `string[]` | No | Specific dimension names to group by (max 10). If omitted, all classifier dimensions are included. Names must be valid identifiers (letters, digits, underscores; max 64 chars). |
-| `include_nulls` | `boolean` | No | When `true`, unclassified rows are included (LEFT JOIN). Default `false` (INNER JOIN — only classified rows). |
+| `include_nulls` | `boolean` | No | When `true`, unclassified rows are included in results. Default `false` (only classified rows). |
 
 **Constraints:**
-- Forces the query to use the raw generations table (31-day time range limit)
+- Limits the query time range to 31 days
 - Single dimension name → result column is aliased to that name (e.g., `category`)
 - Multiple dimension names → result uses generic `clf_dimension_name` / `clf_dimension_value` columns
 
@@ -153,8 +153,8 @@ Classifier filters narrow results to generations matching specific classificatio
 | `filters[].value` | `string \| string[]` | Yes | Scalar for `eq`/`neq`, array for `in`/`not_in` |
 
 **Constraints:**
-- Forces the query to use the raw generations table (31-day time range limit)
-- Only equality/set operators supported (underlying value column is String — ordered comparisons would be lexicographic)
+- Limits the query time range to 31 days
+- Only equality/set operators supported (classification values are strings — ordered comparisons would be lexicographic)
 - All filter field names must be configured dimensions on the classifier
 
 ## Response Schema
@@ -334,10 +334,10 @@ Some metric/dimension combinations support time ranges up to **365 days** (with 
 
 Usage breakdown metrics follow the same pattern: `credits_usage`, `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, and `usage_upstream_web` support up to 365 days, while `openrouter_usage`, `byok_fees`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, and `usage_upstream_web_fetch` are limited to 31 days.
 
-Classifier dimensions and classifier filters always force the 31-day limit (they require the raw generations table via a JOIN on `generation_classifications`).
+Classifier dimensions and classifier filters always force the 31-day time range limit.
 
 If a query times out, try:
 - Narrowing the time range
 - Removing latency/throughput metrics
 - Removing per-generation dimensions (`provider`, `origin`, `country`, `finish_reason`, etc.)
-- Removing classifier dimensions/filters (they require expensive JOINs)
+- Removing classifier dimensions/filters (they are more expensive to compute)

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -181,7 +181,7 @@ Classifier filters narrow results to generations matching specific classificatio
 
 | Field | Description |
 |---|---|
-| `data.data` | Array of result rows. Each row has keys for requested metrics, dimensions, and `date__<granularity>` (when granularity is set, e.g. `date__day`, `date__hour`) |
+| `data.data` | Array of result rows. Each row has keys for requested metrics, dimensions, and `date__<granularity>` (when granularity is set). For `classifier_dimensions` queries with a single `dimension_name`, a column is aliased to that name (e.g., `category`). With multiple names or no `dimension_names`, rows include `clf_dimension_name` and `clf_dimension_value` columns. |
 | `data.metadata.query_time_ms` | Query execution time in milliseconds |
 | `data.metadata.row_count` | Number of rows returned |
 | `data.metadata.truncated` | `true` if results were truncated at the limit |

--- a/skills/openrouter-analytics-query/SKILL.md
+++ b/skills/openrouter-analytics-query/SKILL.md
@@ -44,7 +44,18 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
   ],
   "order_by": { "field": "total_usage", "direction": "desc" },
   "limit": 100,
-  "group_limit": 20
+  "group_limit": 20,
+  "classifier_dimensions": {
+    "classifier_id": "<uuid>",
+    "dimension_names": ["category"],
+    "include_nulls": false
+  },
+  "classifier_filters": {
+    "classifier_id": "<uuid>",
+    "filters": [
+      { "field": "sentiment", "operator": "eq", "value": "positive" }
+    ]
+  }
 }
 ```
 
@@ -65,6 +76,8 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 | `order_by` | `object` | time desc (if granularity set) | `{ field, direction }` where field is a metric, dimension, or `"date"` (short-form alias — maps to `date__day`, `date__hour`, etc. based on granularity) |
 | `limit` | `integer` | 1000 | Maximum total rows to return (1–10,000). On time-series queries with dimensions and no explicit `group_limit`, the server may raise this to accommodate the expected number of time-bucket/dimension combinations. |
 | `group_limit` | `integer` | auto-computed | Maximum rows per distinct dimension combination (ClickHouse LIMIT n BY). When omitted on time-series queries (granularity + dimensions), auto-computed from the time range to guarantee full time-window coverage per group. Explicit values override the default. Ignored when no dimensions are specified. |
+| `classifier_dimensions` | `object` | none | Group by dynamic classifier-produced dimensions. See [Classifier Dimensions](#classifier-dimensions) below. |
+| `classifier_filters` | `object` | none | Filter on classifier-produced dimension values. See [Classifier Filters](#classifier-filters) below. |
 
 ### Filter Object Shape
 
@@ -90,6 +103,60 @@ cd <openrouter-analytics-skill-path>/scripts && npx tsx query-analytics.ts --met
 
 When `granularity` is set and no `order_by` is specified, results are ordered by time descending.
 
+## Classifier Dimensions
+
+Classifier dimensions allow grouping by dynamic, user-defined classification labels (e.g., topic, sentiment, category) produced by a classifier attached to your account. They join the `generation_classifications` table.
+
+```json
+{
+  "classifier_dimensions": {
+    "classifier_id": "550e8400-e29b-41d4-a716-446655440000",
+    "dimension_names": ["category"],
+    "include_nulls": false
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `classifier_id` | `string` (UUID) | Yes | ID of the classifier (must belong to the caller's account) |
+| `dimension_names` | `string[]` | No | Specific dimension names to group by (max 10). If omitted, all classifier dimensions are included. Names must be valid identifiers (letters, digits, underscores; max 64 chars). |
+| `include_nulls` | `boolean` | No | When `true`, unclassified rows are included (LEFT JOIN). Default `false` (INNER JOIN — only classified rows). |
+
+**Constraints:**
+- Forces the query to use the raw generations table (31-day time range limit)
+- Single dimension name → result column is aliased to that name (e.g., `category`)
+- Multiple dimension names → result uses generic `clf_dimension_name` / `clf_dimension_value` columns
+
+## Classifier Filters
+
+Classifier filters narrow results to generations matching specific classification values. They can be used independently or alongside `classifier_dimensions`.
+
+```json
+{
+  "classifier_filters": {
+    "classifier_id": "550e8400-e29b-41d4-a716-446655440000",
+    "filters": [
+      { "field": "category", "operator": "eq", "value": "billing" },
+      { "field": "sentiment", "operator": "in", "value": ["positive", "neutral"] }
+    ]
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `classifier_id` | `string` (UUID) | Yes | ID of the classifier (must belong to the caller's account) |
+| `filters` | `object[]` | Yes | 1–10 filter conditions on classifier dimensions |
+| `filters[].field` | `string` | Yes | Classifier dimension name to filter on |
+| `filters[].operator` | `string` | Yes | One of: `eq`, `neq`, `in`, `not_in` (no `gt`/`lt` — values are strings) |
+| `filters[].value` | `string \| string[]` | Yes | Scalar for `eq`/`neq`, array for `in`/`not_in` |
+
+**Constraints:**
+- Forces the query to use the raw generations table (31-day time range limit)
+- Only equality/set operators supported (underlying value column is String — ordered comparisons would be lexicographic)
+- All filter field names must be configured dimensions on the classifier
+
 ## Response Schema
 
 ```json
@@ -104,7 +171,8 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
       "row_count": 2,
       "truncated": false
     },
-    "cachedAt": 1747699200000
+    "cachedAt": 1747699200000,
+    "warnings": ["Could not resolve api_key_id hash: abc123..."]
   }
 }
 ```
@@ -118,6 +186,7 @@ When `granularity` is set and no `order_by` is specified, results are ordered by
 | `data.metadata.row_count` | Number of rows returned |
 | `data.metadata.truncated` | `true` if results were truncated at the limit |
 | `data.cachedAt` | Unix timestamp (ms) when the result was cached. Present when the response was served from cache |
+| `data.warnings` | Optional array of non-fatal warnings (e.g., unresolvable api_key_id hashes). The query still executes normally; these inform the caller about filter resolution issues. |
 
 > **Numeric types:** Count metrics (`request_count`, `tokens_*`, etc.) are returned as strings (`"1523"`). Cost and rate metrics (`total_usage`, `cache_hit_rate`, latency, throughput) are returned as numbers (`4.27`). Parse count values with `Number()` or `parseInt()` before arithmetic.
 
@@ -265,7 +334,10 @@ Some metric/dimension combinations support time ranges up to **365 days** (with 
 
 Usage breakdown metrics follow the same pattern: `credits_usage`, `usage_upstream`, `usage_cache`, `usage_data`, `usage_web`, and `usage_upstream_web` support up to 365 days, while `openrouter_usage`, `byok_fees`, `usage_file`, `usage_upstream_file`, `usage_web_fetch`, and `usage_upstream_web_fetch` are limited to 31 days.
 
+Classifier dimensions and classifier filters always force the 31-day limit (they require the raw generations table via a JOIN on `generation_classifications`).
+
 If a query times out, try:
 - Narrowing the time range
 - Removing latency/throughput metrics
 - Removing per-generation dimensions (`provider`, `origin`, `country`, `finish_reason`, etc.)
+- Removing classifier dimensions/filters (they require expensive JOINs)

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -147,12 +147,12 @@ All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is w
 
 ## Classifier Dimensions
 
-Beyond the standard dimensions above, you can group by **classifier dimensions** — dynamic labels produced by a user-created classifier (e.g., topic, sentiment, category). Classifier dimensions are joined from the `generation_classifications` ClickHouse table.
+Beyond the standard dimensions above, you can group by **classifier dimensions** — dynamic labels produced by a user-created classifier (e.g., topic, sentiment, category).
 
 - Use the `classifier_dimensions` request field to group by classifier-produced values
 - Use the `classifier_filters` request field to filter on classifier values
 - The classifier must belong to your account (validated server-side)
-- Classifier dimensions/filters always force the raw generations table (31-day limit)
+- Classifier dimensions/filters limit the query time range to 31 days
 - See the `openrouter-analytics-query` skill for the full request shape
 
 ### Mapping Questions to Classifier Queries
@@ -161,7 +161,7 @@ Beyond the standard dimensions above, you can group by **classifier dimensions**
 |---|---|---|
 | "Spend by topic" | `classifier_dimensions: { classifier_id, dimension_names: ["topic"] }` + `metrics: ["total_usage"]` | Single dimension → column aliased to `topic` |
 | "Only billing-related requests" | `classifier_filters: { classifier_id, filters: [{ field: "category", operator: "eq", value: "billing" }] }` | Filters support `eq`, `neq`, `in`, `not_in` only |
-| "Sentiment breakdown including unclassified" | `classifier_dimensions: { classifier_id, dimension_names: ["sentiment"], include_nulls: true }` | LEFT JOIN includes rows without classification |
+| "Sentiment breakdown including unclassified" | `classifier_dimensions: { classifier_id, dimension_names: ["sentiment"], include_nulls: true }` | Includes rows without classification |
 
 ## Understanding Operators
 
@@ -245,6 +245,6 @@ Other dimensions (`provider`, `origin`, `country`, `finish_reason`, `external_us
 - `group_limit` (1–10,000): controls max rows per dimension combination. Auto-computed on time-series queries with dimensions to guarantee full time-window coverage. Set explicitly to cap per-group rows (e.g., top N per model per day).
 - Most volume/cost metrics: up to 365 days with daily granularity
 - Latency/throughput metrics and per-generation dimensions: up to 31 days
-- Classifier dimensions/filters: always limited to 31 days (forces raw generations table)
+- Classifier dimensions/filters: always limited to 31 days
 - Minute granularity: only available when the time window is ≤ 3 hours
 - Rate-limited to 64 requests per minute

--- a/skills/openrouter-analytics-schema/SKILL.md
+++ b/skills/openrouter-analytics-schema/SKILL.md
@@ -145,6 +145,24 @@ All other dimensions (e.g., `model`, `provider`, `country`) are returned as-is w
 - `external_user` — custom user ID passed by the caller
 - `context_length_bucket` — bucketed context length (1K, 10K, 100K, etc.)
 
+## Classifier Dimensions
+
+Beyond the standard dimensions above, you can group by **classifier dimensions** — dynamic labels produced by a user-created classifier (e.g., topic, sentiment, category). Classifier dimensions are joined from the `generation_classifications` ClickHouse table.
+
+- Use the `classifier_dimensions` request field to group by classifier-produced values
+- Use the `classifier_filters` request field to filter on classifier values
+- The classifier must belong to your account (validated server-side)
+- Classifier dimensions/filters always force the raw generations table (31-day limit)
+- See the `openrouter-analytics-query` skill for the full request shape
+
+### Mapping Questions to Classifier Queries
+
+| Question pattern | Request fields | Notes |
+|---|---|---|
+| "Spend by topic" | `classifier_dimensions: { classifier_id, dimension_names: ["topic"] }` + `metrics: ["total_usage"]` | Single dimension → column aliased to `topic` |
+| "Only billing-related requests" | `classifier_filters: { classifier_id, filters: [{ field: "category", operator: "eq", value: "billing" }] }` | Filters support `eq`, `neq`, `in`, `not_in` only |
+| "Sentiment breakdown including unclassified" | `classifier_dimensions: { classifier_id, dimension_names: ["sentiment"], include_nulls: true }` | LEFT JOIN includes rows without classification |
+
 ## Understanding Operators
 
 Filter operators for the `filters` array in query requests:
@@ -221,9 +239,12 @@ Other dimensions (`provider`, `origin`, `country`, `finish_reason`, `external_us
 
 - Maximum 2 dimensions per query
 - Maximum 20 filters per query
+- Maximum 10 classifier dimensions per query
+- Maximum 10 classifier filters per query
 - Maximum 10,000 rows returned per query (default 1,000)
 - `group_limit` (1–10,000): controls max rows per dimension combination. Auto-computed on time-series queries with dimensions to guarantee full time-window coverage. Set explicitly to cap per-group rows (e.g., top N per model per day).
 - Most volume/cost metrics: up to 365 days with daily granularity
 - Latency/throughput metrics and per-generation dimensions: up to 31 days
+- Classifier dimensions/filters: always limited to 31 days (forces raw generations table)
 - Minute granularity: only available when the time window is ≤ 3 hours
 - Rate-limited to 64 requests per minute

--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -30,6 +30,8 @@ cd <skill-path>/scripts && npm install
 | See trends over time | Add `--granularity day` (or `hour`, `week`, `month`) |
 | Reduce costs | Run `suggest-queries.ts`, find the cost optimization template, execute it |
 | Inspect individual generations | Add `--dimensions generation_id`, then use the `openrouter-generations` skill for details |
+| Break down by classifier labels | Use `classifier_dimensions` in the request body (see `openrouter-analytics-query` skill) |
+| Filter by classifier labels | Use `classifier_filters` in the request body (see `openrouter-analytics-query` skill) |
 | Answer a specific question | Map the question → metrics + dimensions, then query |
 
 ## Workflow


### PR DESCRIPTION
## Summary

Syncs analytics skills with query builder changes landed since the last sync (2026-06-17). The main addition is the **classifier dimensions/filters** feature — `classifier_dimensions` and `classifier_filters` are new optional request fields on `POST /api/v1/analytics/query` that allow grouping by and filtering on dynamic, user-defined classification labels (topic, sentiment, category, etc.) from the `generation_classifications` table.

Key changes across three skill files:

- **openrouter-analytics-query**: Full reference for both new request fields (`classifier_dimensions`, `classifier_filters`), including schema tables, constraints (31-day limit, operator restrictions), and column aliasing behavior. Also documents the new `data.warnings` response field for non-fatal filter resolution issues.
- **openrouter-analytics-schema**: Adds a "Classifier Dimensions" section with question→query mapping examples. Updates constraints list with classifier limits.
- **openrouter-analytics**: Adds classifier entries to the decision tree table.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/2cb9ce3993bd43ffa3772ac9ebd18d5a
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->