### PR TITLE
Add OpenRouter benchmarks skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | [openrouter-typescript-sdk](skills/openrouter-typescript-sdk/README.md) | Complete reference for integrating with [600+ AI models](https://openrouter.ai/models) through the OpenRouter TypeScript SDK using the `callModel` pattern |
 | [openrouter-agent-migration](skills/openrouter-agent-migration/README.md) | Migrating from `@openrouter/sdk` to the standalone `@openrouter/agent` package for `callModel`, `tool()`, stop conditions, and streaming helpers |
 | [openrouter-models](skills/openrouter-models/README.md) | Querying available models, comparing pricing, checking context lengths, finding provider performance, and fuzzy model name resolution |
+| [openrouter-benchmarks](skills/openrouter-benchmarks/README.md) | Querying benchmark-backed model rankings from Artificial Analysis and Design Arena via `GET /api/v1/benchmarks` |
 | [openrouter-images](skills/openrouter-images/README.md) | Generating images from text prompts and editing existing images using OpenRouter's image generation models |
 | [openrouter-stt](skills/openrouter-stt/README.md) | Transcribing speech to text via `POST /api/v1/audio/transcriptions` — model discovery, audio format selection, provider-specific options, and zero-dep TypeScript/Python examples |
 | [openrouter-tts](skills/openrouter-tts/README.md) | Synthesizing speech from text via `POST /api/v1/audio/speech` — model/voice discovery, format selection (mp3 vs pcm), provider-specific options, and OpenAI-SDK compatibility |

--- a/skills/openrouter-benchmarks/README.md
+++ b/skills/openrouter-benchmarks/README.md
@@ -1,0 +1,29 @@
+# openrouter-benchmarks
+
+Query OpenRouter's unified benchmark rankings from Artificial Analysis and Design Arena via `GET /api/v1/benchmarks`.
+
+## Install
+
+With the [GitHub CLI](https://cli.github.com/) (v2.90.0+):
+
+```bash
+gh skill install OpenRouterTeam/skills openrouter-benchmarks
+```
+
+Works with Claude Code, Cursor, Codex, OpenCode, Gemini CLI, Windsurf, and [many more agents](https://cli.github.com/manual/gh_skill_install). Add `--scope user` to install across every project for your current agent, or `--agent claude-code` to target a specific agent.
+
+For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) see the [root README](../../README.md#installing).
+
+## Prerequisites
+
+`OPENROUTER_API_KEY` must be set to any valid OpenRouter API key. Get one at [openrouter.ai/keys](https://openrouter.ai/keys).
+
+## What it covers
+
+See [SKILL.md](SKILL.md) for the full reference, including:
+
+- Querying Artificial Analysis and Design Arena benchmark rankings
+- Filtering by benchmark source, task type, arena, category, and result limit
+- Interpreting source-specific scores without mixing incompatible scales
+- Preserving benchmark citation and dataset timestamp metadata
+- Verifying benchmark-ranked candidates against model availability before recommendation

--- a/skills/openrouter-benchmarks/SKILL.md
+++ b/skills/openrouter-benchmarks/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: openrouter-benchmarks
+description: Query OpenRouter's Benchmarks API for model benchmark rankings and scores. Use when the user asks for benchmark-backed model selection, model rankings by coding/intelligence/agentic ability, Artificial Analysis or Design Arena ELO/win-rate results, benchmark citations, or wants to call GET /api/v1/benchmarks. Also use alongside openrouter-models when the user asks what model should power an app, product, workflow, or use case and benchmark evidence could inform or rule out part of the recommendation, including creative writing, editing, coding, design, agentic, or intelligence-heavy apps. Do not use for OpenRouter usage analytics, billing/spend analysis, generation metadata, provider uptime/latency, generic model pricing/capability lookup without any selection or benchmark-relevance decision, or creating an evaluation suite for a local app.
+---
+
+# OpenRouter Benchmarks
+
+Use OpenRouter's unified benchmarks endpoint to answer benchmark-backed model ranking and model-selection questions. The endpoint aggregates Artificial Analysis and Design Arena data and returns citation metadata that should be preserved when reporting results.
+
+## Prerequisites
+
+Set `OPENROUTER_API_KEY` to any valid OpenRouter API key. Benchmarks do not require a management key.
+
+```bash
+export OPENROUTER_API_KEY=sk-or-v1-...
+```
+
+## Decision Tree
+
+| User wants to... | Action |
+|---|---|
+| See benchmark-ranked models across sources | Call `GET /api/v1/benchmarks` and preserve source/citation metadata |
+| Choose a model for an app/use case | Check whether Artificial Analysis or Design Arena contains a relevant signal; say when no direct benchmark exists |
+| Find best coding, intelligence, or agentic models | Use `task_type=coding`, `task_type=intelligence`, or `task_type=agentic` |
+| Query Artificial Analysis only | Use `source=artificial-analysis` |
+| Query Design Arena only | Use `source=design-arena`, plus `arena` and `category` when relevant |
+| Get raw API-shaped data for integration work | Return the raw `data`/`meta` shape from the endpoint |
+| Understand all response fields or direct curl usage | Read `references/benchmarks-api.md` |
+
+Use `openrouter-models` instead when the user needs pricing, context length, supported parameters, modalities, or provider endpoint performance without asking for benchmark rankings.
+
+For creative writing, storytelling, or editorial apps, this endpoint currently has no direct writing-quality benchmark. Treat Artificial Analysis `intelligence_index` as a weak general-capability signal, and use `agentic_index` only if the app performs multi-step planning/revision. Do not imply that Design Arena visual/code categories measure prose quality.
+
+## Availability Gate
+
+Do not recommend a benchmark-ranked model until it passes an availability check through the models/endpoints API. Benchmark rows can contain dated or benchmark-specific `model_permaslug` values that are useful for attribution but are not always the exact routable OpenRouter model ID.
+
+Before recommending a benchmark candidate:
+
+1. Check `GET /api/v1/models` for an exact `id` match to the benchmark `model_permaslug`.
+2. If there is no exact `id` match but a model has `canonical_slug` equal to the benchmark `model_permaslug`, treat the benchmark row as evidence for that model family, not as a directly recommendable ID. Use the model's actual `id` only after verifying availability.
+3. Check `GET /api/v1/models/{author}/{slug}/endpoints` or use `openrouter-models` `get-endpoints.ts` for provider status.
+4. Prefer candidates with at least one clearly usable endpoint. If all endpoints are degraded, have `uptime_last_30m: 0`, or the OpenRouter model page/API indicates the model is unavailable, exclude it from primary recommendations and explain that the benchmark result is not currently actionable.
+5. When availability is ambiguous, say so and recommend a verified available alternative instead of presenting the benchmark leader as the default choice.
+
+Do not rely on endpoint `status: 0` alone. Model-level availability signals such as routing error messages, warning messages, zero request limits, empty endpoint lists, or provider-specific access restrictions can make a benchmark leader non-actionable even when one endpoint appears operational. If availability signals disagree, explain the ambiguity and avoid making that model the primary recommendation.
+
+## API Usage
+
+Query parameters:
+
+| Flag | Values | Notes |
+|---|---|---|
+| `source` | `artificial-analysis`, `design-arena` | Omitting it returns all sources. |
+| `task_type` | `coding`, `intelligence`, `agentic` | Maps to source-specific indices/categories. |
+| `arena` | `models`, `builders`, `agents` | Design Arena only; defaults server-side to `models`. |
+| `category` | `codecategories`, `uicomponent`, `gamedev`, `3d`, `dataviz`, `image`, `video`, `svg`, etc. | Design Arena only. |
+| `max_results` | positive integer | Maximum number of rows returned by the API. |
+
+Always preserve `meta.citation`, `meta.source_url`, and `meta.as_of`; include attribution when republishing benchmark data.
+
+When results include both sources, do not present them as a single absolute leaderboard: Artificial Analysis indices and Design Arena ELO use different scales. Compare within each source, or rerun with `source=artificial-analysis` or `source=design-arena` for a source-specific ranking.
+
+## Interpreting Results
+
+- Artificial Analysis rows include `intelligence_index`, `coding_index`, and `agentic_index`; higher is better.
+- Design Arena rows include `elo`, `win_rate`, `avg_generation_time_ms`, `arena`, `category`, and `tournament_stats`; higher `elo`/`win_rate` is better, lower generation time is faster.
+- `pricing.prompt` and `pricing.completion` are USD per token as decimal strings. Multiply by 1,000,000 for per-million-token costs.
+- `model_permaslug` identifies the benchmarked model entry. Verify it against `GET /api/v1/models` before using it as a chat/completions model ID.
+- `meta.model_count` counts unique models in the response, which can differ from `data.length` when multiple Design Arena categories are returned.
+
+## Direct API Call
+
+```bash
+curl 'https://openrouter.ai/api/v1/benchmarks?source=artificial-analysis&task_type=coding&max_results=10' \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY"
+```
+
+Read `references/benchmarks-api.md` when implementing against the raw API or handling source-specific response shapes.

--- a/skills/openrouter-benchmarks/agents/openai.yaml
+++ b/skills/openrouter-benchmarks/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OpenRouter Benchmarks"
+  short_description: "Query model benchmark rankings"
+  default_prompt: "Use $openrouter-benchmarks to find benchmark-ranked OpenRouter models for coding."

--- a/skills/openrouter-benchmarks/references/benchmarks-api.md
+++ b/skills/openrouter-benchmarks/references/benchmarks-api.md
@@ -1,0 +1,108 @@
+# OpenRouter Benchmarks API Reference
+
+Source: https://openrouter.ai/docs/api/api-reference/benchmarks/get-benchmarks.md
+
+## Endpoint
+
+```http
+GET https://openrouter.ai/api/v1/benchmarks
+Authorization: Bearer <OPENROUTER_API_KEY>
+```
+
+The endpoint aggregates Artificial Analysis and Design Arena benchmark scores. It is authenticated with any valid OpenRouter API key and rate-limited to 30 requests/minute per key and 500 requests/day per account.
+
+## Query Parameters
+
+| Parameter | Values | Description |
+|---|---|---|
+| `source` | `artificial-analysis`, `design-arena` | Benchmark source. Omitting it returns all sources. The source determines row shape. |
+| `task_type` | `coding`, `intelligence`, `agentic` | Workload filter. For Artificial Analysis, maps to the corresponding index. For Design Arena, maps to the matching category. |
+| `arena` | `models`, `builders`, `agents` | Design Arena only. Defaults to `models` when `source=design-arena`. |
+| `category` | string | Design Arena category such as `codecategories`, `uicomponent`, `gamedev`, `3d`, `dataviz`, `image`, `video`, or `svg`. Omitting it returns all categories. |
+| `max_results` | integer >= 1 | Maximum number of items to return. Omitting it returns all matching results. |
+
+## Response Shape
+
+```ts
+type UnifiedBenchmarksResponse = {
+  data: Array<ArtificialAnalysisItem | DesignArenaItem>;
+  meta: {
+    as_of: string;
+    citation: string | null;
+    model_count: number;
+    source: "artificial-analysis" | "design-arena" | null;
+    source_url: string | null;
+    task_type: string | null;
+    version: "v1";
+  };
+};
+```
+
+### Artificial Analysis Item
+
+```ts
+type ArtificialAnalysisItem = {
+  source: "artificial-analysis";
+  model_permaslug: string;
+  display_name: string;
+  intelligence_index: number | null;
+  coding_index: number | null;
+  agentic_index: number | null;
+  pricing: { prompt: string; completion: string } | null;
+};
+```
+
+Higher index scores are better. Use `coding_index`, `intelligence_index`, or `agentic_index` according to the user request. If the user did not name a task, prefer `intelligence_index` for general capability ranking.
+
+### Design Arena Item
+
+```ts
+type DesignArenaItem = {
+  source: "design-arena";
+  model_permaslug: string;
+  display_name: string;
+  arena: string;
+  category: string;
+  elo: number;
+  win_rate: number;
+  avg_generation_time_ms: number | null;
+  tournament_stats: {
+    first_place: number | null;
+    second_place: number | null;
+    third_place: number | null;
+    fourth_place: number | null;
+    total: number | null;
+  };
+  pricing: { prompt: string; completion: string } | null;
+};
+```
+
+Higher `elo` and `win_rate` are better. `avg_generation_time_ms` is performance context, not the ranking score.
+
+## Errors
+
+| Status | Meaning | Recovery |
+|---|---|---|
+| `400` | Invalid parameters or malformed input | Check enum spelling and incompatible Design Arena-only parameters. |
+| `401` | Missing or invalid API key | Set `OPENROUTER_API_KEY` or pass an `Authorization: Bearer <key>` header. |
+| `429` | Rate limit exceeded | Wait before retrying; avoid repeated broad pulls. |
+| `500` | Server error | Retry later or narrow filters. |
+
+## Reporting Guidance
+
+When answering users, include the benchmark source, `meta.as_of`, and the citation/source URL if present. If results mix sources and `meta.citation` is null, attribute each row by its `source` discriminator.
+
+## Availability Caveat
+
+Treat benchmark rows as evidence, not as sufficient proof that a model is currently usable. `model_permaslug` can be a benchmark/canonical slug that differs from the routable model `id` returned by `GET /api/v1/models`.
+
+Before recommending a benchmark leader for production use:
+
+1. Look up the candidate in `GET /api/v1/models` by exact `id`.
+2. If no exact `id` exists, look for a model whose `canonical_slug` equals the benchmark `model_permaslug` and use that model's actual `id` only after checking endpoints.
+3. Check `GET /api/v1/models/{author}/{slug}/endpoints` for provider status, uptime, latency, and throughput.
+4. Exclude candidates whose model page/API indicates they are unavailable or whose endpoints are all unusable/degraded. Mention that their benchmark ranking is not currently actionable.
+
+This matters whenever benchmark rankings reference a dated, alias, or canonical slug while the models API exposes a different routable ID or model-level availability restrictions.
+
+Endpoint `status: 0` is not always sufficient for recommendation quality. Also inspect model-level availability signals when available, including routing error messages, warning messages, zero request limits, provider-specific access restrictions, and empty endpoint lists for alias/latest models. If these indicate the model is unavailable or not publicly usable, skip it as a primary recommendation even if benchmark scores are high.


### PR DESCRIPTION
## Summary
- add an `openrouter-benchmarks` skill for the new `GET /api/v1/benchmarks` endpoint
- document source/task/category query usage, response shapes, attribution metadata, and availability checks
- add UI metadata and list the skill in the root README

## Validation
- `quick_validate.py skills/openrouter-benchmarks`
- `git diff --check`
- confirmed the skill is Markdown-only and has no package/script install requirements