### PR TITLE
docs(analytics): document session_id dimension

### DIFF
--- a/skills/openrouter-analytics/SKILL.md
+++ b/skills/openrouter-analytics/SKILL.md
@@ -127,7 +127,7 @@ When interpreting results for the user:
 - **Rates** (`cache_hit_rate`) are 0–1 ratios
 - **Throughput** (`avg_throughput`) is tokens per second
 - When `granularity` is set, rows include a `date__<granularity>` field for the time bucket (e.g., `date__day`, `date__hour`, `date__month`)
-- **Label resolution**: dimensions `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (key name, app title, user name, workspace name) directly in the data rows
+- **Label resolution**: dimensions `api_key_id`, `app`, `user`, and `workspace` have their raw IDs replaced with human-readable names (key name, app title, user name, workspace name) directly in the data rows; `generation_id` and `session_id` return raw values
 - **Truncation**: when consuming output programmatically, check `metadata.truncated`. If `true`, the result was capped at `--limit` and is a *partial* dataset — raise `--limit` or paginate before reporting totals or rankings
 
 ### Cost Optimization Guidance
@@ -145,7 +145,7 @@ When the user asks "How can I spend less?" or similar:
 
 ## Drilling Down to Individual Generations
 
-To inspect specific generations from your analytics results, add `generation_id` as a dimension. This is a generations-only dimension (31-day limit) that returns the unique ID for each generation in the result set.
+To inspect specific generations or sessions from your analytics results, add `generation_id` or `session_id` as a dimension. Both are generations-only dimensions (31-day limit). `generation_id` returns the unique ID for each generation in the result set. `session_id` groups and filters sessionless requests as the literal `none`: the ClickHouse column defaults to an empty string, and the query builder coalesces it to `none`. Use `neq 'none'` to exclude sessionless requests; filtering on `''` matches nothing.
 
 ```bash
 npx tsx query-analytics.ts --metrics total_usage,tokens_total --dimensions generation_id --order-by total_usage --limit 10


### PR DESCRIPTION
## Summary

Documents the `session_id` analytics dimension added in OpenRouterTeam/openrouter-web#30762, in the two places the skill already tracks per-dimension behavior: the drill-down section and the label-resolution note.

The non-obvious part worth documenting is the sentinel. `generations.session_id` is `String DEFAULT ''`, and the dimension carries a `generationsExpression` that coalesces it:

```sql
if(session_id = '', 'none', session_id)
```

Because that expression is used for WHERE as well as SELECT/GROUP BY, `eq ''` matches nothing and `neq 'none'` is the way to exclude sessionless requests — which is exactly the kind of thing an agent reading this skill would otherwise get wrong on the first try.

Also notes that `generation_id` and `session_id` return raw values, since the label-resolution list previously only said which dimensions *are* resolved.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/f096dd4e5984432ca1c4a8819b51bfbc
Requested by: @jtcies
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->