### PR TITLE
Add spawn-ori-eval skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | [openrouter-analytics-schema](skills/openrouter-analytics-schema/README.md) | Discovering the OpenRouter analytics schema — available metrics, dimensions, filter operators, and granularities, and mapping natural-language questions to query parameters |
 | [openrouter-analytics-query](skills/openrouter-analytics-query/README.md) | Constructing and executing analytics queries against the OpenRouter API — full parameter reference for metrics, dimensions, filters, time ranges, ordering, and pagination |
 | [openrouter-generations](skills/openrouter-generations/README.md) | Inspecting individual OpenRouter generations — request metadata (cost, latency, tokens, model, provider routing) and stored prompt/completion content |
-| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/ori/code) — spawning `ori code -p` so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
+| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/ori/code) — spawning a headless Ori run so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | [openrouter-analytics](skills/openrouter-analytics/README.md) | Answering natural-language questions about your OpenRouter usage data — spend, request volume, model breakdown, latency, token usage, and cost optimization |
 | [openrouter-analytics-schema](skills/openrouter-analytics-schema/README.md) | Discovering the OpenRouter analytics schema — available metrics, dimensions, filter operators, and granularities, and mapping natural-language questions to query parameters |
 | [openrouter-analytics-query](skills/openrouter-analytics-query/README.md) | Constructing and executing analytics queries against the OpenRouter API — full parameter reference for metrics, dimensions, filters, time ranges, ordering, and pagination |
+| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/labs/ori) — spawning `ori code -p` so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
 | [openrouter-generations](skills/openrouter-generations/README.md) | Inspecting individual OpenRouter generations — request metadata (cost, latency, tokens, model, provider routing) and stored prompt/completion content |
 
 ## Environment

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | [openrouter-analytics-schema](skills/openrouter-analytics-schema/README.md) | Discovering the OpenRouter analytics schema — available metrics, dimensions, filter operators, and granularities, and mapping natural-language questions to query parameters |
 | [openrouter-analytics-query](skills/openrouter-analytics-query/README.md) | Constructing and executing analytics queries against the OpenRouter API — full parameter reference for metrics, dimensions, filters, time ranges, ordering, and pagination |
 | [openrouter-generations](skills/openrouter-generations/README.md) | Inspecting individual OpenRouter generations — request metadata (cost, latency, tokens, model, provider routing) and stored prompt/completion content |
-| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/ori) — spawning `ori code -p` so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
+| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/ori/code) — spawning `ori code -p` so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | [openrouter-analytics-schema](skills/openrouter-analytics-schema/README.md) | Discovering the OpenRouter analytics schema — available metrics, dimensions, filter operators, and granularities, and mapping natural-language questions to query parameters |
 | [openrouter-analytics-query](skills/openrouter-analytics-query/README.md) | Constructing and executing analytics queries against the OpenRouter API — full parameter reference for metrics, dimensions, filters, time ranges, ordering, and pagination |
 | [openrouter-generations](skills/openrouter-generations/README.md) | Inspecting individual OpenRouter generations — request metadata (cost, latency, tokens, model, provider routing) and stored prompt/completion content |
-| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/labs/ori) — spawning `ori code -p` so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
+| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/ori) — spawning `ori code -p` so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | [openrouter-analytics](skills/openrouter-analytics/README.md) | Answering natural-language questions about your OpenRouter usage data — spend, request volume, model breakdown, latency, token usage, and cost optimization |
 | [openrouter-analytics-schema](skills/openrouter-analytics-schema/README.md) | Discovering the OpenRouter analytics schema — available metrics, dimensions, filter operators, and granularities, and mapping natural-language questions to query parameters |
 | [openrouter-analytics-query](skills/openrouter-analytics-query/README.md) | Constructing and executing analytics queries against the OpenRouter API — full parameter reference for metrics, dimensions, filters, time ranges, ordering, and pagination |
-| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/labs/ori) — spawning `ori code -p` so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
 | [openrouter-generations](skills/openrouter-generations/README.md) | Inspecting individual OpenRouter generations — request metadata (cost, latency, tokens, model, provider routing) and stored prompt/completion content |
+| [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/labs/ori) — spawning `ori code -p` so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
 
 ## Environment
 

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -1,6 +1,6 @@
 # spawn-ori-eval
 
-Delegate model evals to [Ori](https://openrouter.ai/ori): spawn `ori code -p` as a subprocess so the eval is authored and graded on a pinned harness and model, then relay the ranked results.
+Delegate model evals to [Ori](https://openrouter.ai/ori/code): spawn `ori code -p` as a subprocess so the eval is authored and graded on a pinned harness and model, then relay the ranked results.
 
 ## Install
 

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -1,6 +1,6 @@
 # spawn-ori-eval
 
-Delegate model evals to [Ori](https://openrouter.ai/ori/code): spawn `ori code -p` as a subprocess so the eval is authored and graded on a pinned harness and model, then relay the ranked results.
+Delegate model evals to [Ori](https://openrouter.ai/ori/code): spawn a headless Ori run as a subprocess so the eval is authored and graded on a pinned harness and model, then relay the ranked results.
 
 ## Install
 
@@ -26,7 +26,7 @@ See [SKILL.md](SKILL.md) for the full reference, including:
 
 - Preflight for the `ori` binary, auth, and Bun, including the `~/.local/bin` PATH gap
 - Scoping one feature, ranking axis, cost ceiling, and baseline model before spawning, because Ori runs headless
-- Backgrounding a single `ori code -p` invocation without overriding the pinned harness or model
+- Backgrounding a single headless Ori invocation (command placeholder pending launch devex) without overriding the pinned harness or model
 - A fill-in-the-blanks task prompt that produces a reproducible `evals/<feature>.eval.ts`
 - Anti-patterns: self-authored evals, subagent "evals", evals hidden in the repo's own test framework
 - Turning the run into a guardrail with cheap `ori eval` re-runs in CI

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -17,7 +17,7 @@ For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) s
 ## Prerequisites
 
 - `ori` on PATH — `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`
-- Ori auth — `~/.ori/credentials.json` (via `ori login`) or `OPENROUTER_API_KEY`
+- Ori auth — `~/.ori/credentials.json` (via `ori login`)
 - [Bun](https://bun.sh), which Ori uses to execute `*.eval.ts`
 
 ## What it covers

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -1,6 +1,6 @@
 # spawn-ori-eval
 
-Delegate model evals to [Ori](https://openrouter.ai/labs/ori): spawn `ori code -p` as a subprocess so the eval is authored and graded on a pinned harness and model, then relay the ranked results.
+Delegate model evals to [Ori](https://openrouter.ai/ori): spawn `ori code -p` as a subprocess so the eval is authored and graded on a pinned harness and model, then relay the ranked results.
 
 ## Install
 

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -1,0 +1,32 @@
+# spawn-ori-eval
+
+Delegate model evals to [Ori](https://openrouter.ai/labs/ori): spawn `ori code -p` as a subprocess so the eval is authored and graded on a pinned harness and model, then relay the ranked results.
+
+## Install
+
+With the [GitHub CLI](https://cli.github.com/) (v2.90.0+):
+
+```bash
+gh skill install OpenRouterTeam/skills spawn-ori-eval
+```
+
+Works with Claude Code, Cursor, Codex, OpenCode, Gemini CLI, Windsurf, and [many more agents](https://cli.github.com/manual/gh_skill_install). Add `--scope user` to install across every project for your current agent, or `--agent claude-code` to target a specific agent.
+
+For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) see the [root README](../../README.md#installing).
+
+## Prerequisites
+
+- `ori` on PATH — `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`
+- Ori auth — `~/.ori/credentials.json` (via `ori login`) or `OPENROUTER_API_KEY`
+- [Bun](https://bun.sh), which Ori uses to execute `*.eval.ts`
+
+## What it covers
+
+See [SKILL.md](SKILL.md) for the full reference, including:
+
+- Preflight for the `ori` binary, auth, and Bun, including the `~/.local/bin` PATH gap
+- Scoping one feature, ranking axis, cost ceiling, and baseline model before spawning, because Ori runs headless
+- Backgrounding a single `ori code -p` invocation without overriding the pinned harness or model
+- A fill-in-the-blanks task prompt that produces a reproducible `evals/<feature>.eval.ts`
+- Anti-patterns: self-authored evals, subagent "evals", evals hidden in the repo's own test framework
+- Turning the run into a guardrail with cheap `ori eval` re-runs in CI

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -23,7 +23,7 @@ Run these in order. Do not skip ahead on a failure.
 
 3. `command -v bun`. Ori executes `*.eval.ts` through Bun.
 
-Never print, echo, or log the contents of `credentials.json`, the value of `OPENROUTER_API_KEY`, or any other value you read out of a `.env` file or config while searching. Name the key, never the value: `OPENAI_API_KEY at .env:4`, not the key itself.
+Never print, echo, or log the contents of `credentials.json`, the value of `OPENROUTER_API_KEY`, or any other value you read out of a `.env` file or config while searching. Name the key, never the value: `OPENAI_API_KEY at .env:4`, not what it is set to.
 
 ## 2. Scope it before you spawn
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -19,11 +19,11 @@ Run these in order. Do not skip ahead on a failure.
 
    It installs to `~/.local/bin`, which is often not on PATH in a non-login shell. Re-check with `~/.local/bin/ori --version` before reporting failure.
 
-2. Auth: `~/.ori/credentials.json` must exist, or `OPENROUTER_API_KEY` must be set. If neither, STOP and hand it back to the user. `ori login` opens a browser and you cannot complete it. Tell them to run it themselves. In Claude Code, tell them to type `! ori login`.
+2. Auth: `~/.ori/credentials.json` must exist. It is created by `ori login` and scoped specifically to Ori; do not substitute a raw `OPENROUTER_API_KEY`. If it is missing, STOP and hand it back to the user. `ori login` opens a browser and you cannot complete it. Tell them to run it themselves. In Claude Code, tell them to type `! ori login`.
 
 3. `command -v bun`. Ori executes `*.eval.ts` through Bun.
 
-Never print, echo, or log the contents of `credentials.json`, the value of `OPENROUTER_API_KEY`, or any other value you read out of a `.env` file or config while searching. Name the key, never the value: `OPENAI_API_KEY at .env:4`, not what it is set to.
+Never print, echo, or log the contents of `credentials.json` or any other value you read out of a `.env` file or config while searching. Name the key, never the value: `OPENAI_API_KEY at .env:4`, not what it is set to.
 
 ## 2. Scope it before you spawn
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -5,7 +5,7 @@ description: Spawn Ori as a subprocess to run a model eval on a pinned harness a
 
 # Spawn Ori Eval
 
-You are not going to write this eval. You are going to install Ori if needed, scope the eval with the user, hand it to `ori code -p`, and relay what comes back.
+You are not going to write this eval. You are going to install Ori if needed, scope the eval with the user, hand it to a headless Ori run, and relay what comes back.
 
 That split is deliberate. Ori pins the harness and the model that author and grade the eval, so the bench is identical no matter which coding agent the user happens to be driving. An eval you author yourself is not reproducible, and a score change has to mean the user's agent changed, not the environment.
 
@@ -40,19 +40,22 @@ Tell the user these answers are frozen once the run starts.
 
 ## 3. Spawn it
 
+<!-- TODO(launch): placeholder — the headless invocation devex is not final. Replace this command block with the real one before launch. -->
+
 ```bash
-ori code -p "$(cat /tmp/ori-task.txt)" > /tmp/ori-run.log 2>&1 &
+# PLACEHOLDER — headless invocation command TBD, update before launch
+<ori-headless-invocation> "$(cat /tmp/ori-task.txt)" > /tmp/ori-run.log 2>&1 &
 ```
 
 - Background it. A real run outlasts most agents' foreground command timeout. Poll the log; do not block.
 - Do NOT pass `--model` or `--harness`. Overriding the pin destroys the reproducibility that is the only reason to use Ori.
 - Run from the repo root so Ori can read the real prompts.
-- One invocation. Do not loop `ori code` once per candidate model. Comparing models is `ori eval`'s job, not yours.
+- One invocation. Do not loop the headless run once per candidate model. Comparing models is `ori eval`'s job, not yours.
 - The first `ori` run on a machine creates `~/.ori/global` and fetches templates over the network. Expect a pause of roughly 30 seconds and do not treat it as a hang.
 
 ## 4. The task prompt
 
-Write this to `/tmp/ori-task.txt` — the file section 3 cats — and fill every angle-bracket slot. If you use a different path, use it in the spawn command too; an unwritten path cats to an empty prompt and Ori does nothing.
+Write this to `/tmp/ori-task.txt` — the file the section 3 command cats — and fill every angle-bracket slot. If you use a different path, use it in the spawn command too; an unwritten path cats to an empty prompt and Ori does nothing.
 
 ```text
 Use the writing-evals skill.
@@ -85,7 +88,7 @@ models.
 ## 5. Never do these
 
 - **Never spawn your own subagent to "do an eval."** It produces a plausible table with no pinned bench behind it, which is worse than no answer.
-- **Never write the eval yourself.** Ori's `writing-evals` skill fires automatically inside `ori code`.
+- **Never write the eval yourself.** Ori's `writing-evals` skill fires automatically inside the headless run.
 - **Never put the eval in the repo's existing test framework.** `ori eval` discovers `*.eval.ts` only. A pytest, vitest, or Go test file silently never runs, and silence reads as passing.
 - **Never hand-roll raw API calls and present the numbers as an Ori eval.** If you measure something another way, label it clearly as such.
 - **Never name model ids or prices from memory.** They go stale between releases.
@@ -94,7 +97,7 @@ models.
 ## 6. After the run
 
 - The `*.eval.ts` file is the durable artifact. Tell the user to commit it.
-- Re-runs do not need `ori code`. `ori eval evals/<feature>.eval.ts` is enough and much cheaper. This is what turns a one-off answer into a guardrail.
+- Re-runs do not need a full headless run. `ori eval evals/<feature>.eval.ts` is enough and much cheaper. This is what turns a one-off answer into a guardrail.
 - Offer to wire `ori eval` into CI so a worse agent fails the build.
 - Relay the full table, the ship or no-ship call, and the quoted failures. Do not summarize away the failure quotes; they are the most useful output.
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -23,7 +23,7 @@ Run these in order. Do not skip ahead on a failure.
 
 3. `command -v bun`. Ori executes `*.eval.ts` through Bun.
 
-Never print, echo, or log the contents of `credentials.json` or the value of `OPENROUTER_API_KEY`.
+Never print, echo, or log the contents of `credentials.json`, the value of `OPENROUTER_API_KEY`, or any other value you read out of a `.env` file or config while searching. Name the key, never the value: `OPENAI_API_KEY at .env:4`, not the key itself.
 
 ## 2. Scope it before you spawn
 
@@ -52,7 +52,7 @@ ori code -p "$(cat /tmp/ori-task.txt)" > /tmp/ori-run.log 2>&1 &
 
 ## 4. The task prompt
 
-Write this to a file and pass it with `-p`. Fill every angle-bracket slot.
+Write this to `/tmp/ori-task.txt` — the file section 3 cats — and fill every angle-bracket slot. If you use a different path, use it in the spawn command too; an unwritten path cats to an empty prompt and Ori does nothing.
 
 ```text
 Use the writing-evals skill.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: spawn-ori-eval
+description: Spawn Ori as a subprocess to run a model eval on a pinned harness and model, then relay the results. Use when the user asks which model they should use, wants to compare or bake off models, wants to measure whether their agent or prompt does the right thing, wants to catch regressions in agent behavior, or asks how good their current model is. Applies to any codebase in any language. Do not use for plain unit tests that involve no model, and do not use to re-run an eval that already exists (run `ori eval <file>` directly).
+---
+
+# Spawn Ori Eval
+
+You are not going to write this eval. You are going to install Ori if needed, scope the eval with the user, hand it to `ori code -p`, and relay what comes back.
+
+That split is deliberate. Ori pins the harness and the model that author and grade the eval, so the bench is identical no matter which coding agent the user happens to be driving. An eval you author yourself is not reproducible, and a score change has to mean the user's agent changed, not the environment.
+
+## 1. Preflight
+
+Run these in order. Do not skip ahead on a failure.
+
+1. `command -v ori`
+
+   If missing: `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`
+
+   It installs to `~/.local/bin`, which is often not on PATH in a non-login shell. Re-check with `~/.local/bin/ori --version` before reporting failure.
+
+2. Auth: `~/.ori/credentials.json` must exist, or `OPENROUTER_API_KEY` must be set. If neither, STOP and hand it back to the user. `ori login` opens a browser and you cannot complete it. Tell them to run it themselves. In Claude Code, tell them to type `! ori login`.
+
+3. `command -v bun`. Ori executes `*.eval.ts` through Bun.
+
+Never print, echo, or log the contents of `credentials.json` or the value of `OPENROUTER_API_KEY`.
+
+## 2. Scope it before you spawn
+
+Ori runs headless. Once it starts it cannot ask the user anything, so every decision has to be made now.
+
+1. Find every model call site in the repo. Search for `openrouter`, `anthropic`, `openai`, `chat.completions`, `messages.create`, `model=`, `MODEL`, and model ids in config files and `.env` keys.
+2. Report what you found, grouped by feature, with file and line.
+3. Ask the user to pick exactly ONE feature. A repo with a support bot, a summarizer, and a classifier needs three separate evals, not one blended score.
+4. Ask what the model needs to be good at, in their own words. Do not offer four canned options; the real answer is usually a sentence.
+5. Ask for a cost ceiling per call.
+6. Confirm which model is in production today. It becomes the baseline row.
+
+Tell the user these answers are frozen once the run starts.
+
+## 3. Spawn it
+
+```bash
+ori code -p "$(cat /tmp/ori-task.txt)" > /tmp/ori-run.log 2>&1 &
+```
+
+- Background it. A real run outlasts most agents' foreground command timeout. Poll the log; do not block.
+- Do NOT pass `--model` or `--harness`. Overriding the pin destroys the reproducibility that is the only reason to use Ori.
+- Run from the repo root so Ori can read the real prompts.
+- One invocation. Do not loop `ori code` once per candidate model. Comparing models is `ori eval`'s job, not yours.
+- The first `ori` run on a machine creates `~/.ori/global` and fetches templates over the network. Expect a pause of roughly 30 seconds and do not treat it as a hang.
+
+## 4. The task prompt
+
+Write this to a file and pass it with `-p`. Fill every angle-bracket slot.
+
+```text
+Use the writing-evals skill.
+
+Feature under test: <feature name>
+Real prompt and call site: <paths>. Read these first and use the actual
+production prompt, not a paraphrase.
+Model in production today: <model id> at <file:line>. Include it as the
+baseline row.
+
+Rank primarily on: <the user's words, verbatim>
+Secondary axes, reported as tiebreakers: <axes>
+Hard gate: fail any model above <N> per call and mark it as a cost failure.
+
+Compare the production model plus 4 or 5 other currently available models. Look
+up real per-token pricing. Do not recall model ids from memory.
+
+Cases must span: fully covered by context, partially covered, not covered at
+all, adversarial pressure for something the context does not support, and
+<domain-specific cases>.
+
+Write the eval to evals/<feature>.eval.ts and run it with ori eval. Do not
+create or modify anything outside the evals directory.
+
+Report a ranked table, state plainly whether anything beats the production model
+by enough to justify a swap, and quote 2 or 3 concrete failures from the losing
+models.
+```
+
+## 5. Never do these
+
+- **Never spawn your own subagent to "do an eval."** It produces a plausible table with no pinned bench behind it, which is worse than no answer.
+- **Never write the eval yourself.** Ori's `writing-evals` skill fires automatically inside `ori code`.
+- **Never put the eval in the repo's existing test framework.** `ori eval` discovers `*.eval.ts` only. A pytest, vitest, or Go test file silently never runs, and silence reads as passing.
+- **Never hand-roll raw API calls and present the numbers as an Ori eval.** If you measure something another way, label it clearly as such.
+- **Never name model ids or prices from memory.** They go stale between releases.
+- **Never report a winner without the production model in the table.** "No change" is a valid and useful result.
+
+## 6. After the run
+
+- The `*.eval.ts` file is the durable artifact. Tell the user to commit it.
+- Re-runs do not need `ori code`. `ori eval evals/<feature>.eval.ts` is enough and much cheaper. This is what turns a one-off answer into a guardrail.
+- Offer to wire `ori eval` into CI so a worse agent fails the build.
+- Relay the full table, the ship or no-ship call, and the quoted failures. Do not summarize away the failure quotes; they are the most useful output.
+
+## 7. If something goes wrong
+
+| Symptom | Do this |
+|---|---|
+| `ori: command not found` after a successful install | Try `~/.local/bin/ori`. The installer's PATH edit does not apply to the current shell. |
+| Auth missing | Stop. Ask the user to run `ori login` themselves. |
+| Long silence on the first run | Template fetch, roughly 30s. Wait before retrying. |
+| Ori reports a model id as unavailable | Have it look the id up again rather than substituting one from memory. |
+| The eval file landed outside `evals/` | Move it and re-run `ori eval` against the new path. |
+| Run exceeds your timeout | It was backgrounded. Keep polling the log, do not re-spawn. |


### PR DESCRIPTION

## Summary

New public skill `skills/spawn-ori-eval/` whose reader is another coding agent (Claude Code, Codex, opencode, Cursor) that has never heard of Ori. It teaches dispatch, not authoring: the reader installs `ori` if needed, scopes exactly one feature with the user, backgrounds a single `ori code -p "$(cat /tmp/ori-task.txt)"`, and relays the ranked table. A reader finishes having written zero eval code.

Why dispatch rather than "just write the eval": Ori pins the harness and the model that author and grade the eval, so a score change means the user's agent changed, not the bench. Self-authored evals, subagent "evals", and hand-rolled API calls all defeat that and are called out as explicit anti-patterns.

Distinct from the `writing-evals` skill bundled in the Ori binary — that one is read by the agent *inside* `ori code` and covers authoring; this one is read from outside and covers spawning. The task-prompt template here opens with `Use the writing-evals skill.` so the two chain rather than overlap.

Deviations from the requested content, to match repo conventions:
- `description` is a single-line scalar, matching every other skill's frontmatter, rather than a YAML folded (`>`) block. Content is unchanged apart from `TRIGGER when` → `Use when` and `Do NOT trigger` → `Do not use`, which is the phrasing the other skills' descriptions use for the same purpose.
- Added `skills/spawn-ori-eval/README.md` and a row in the root README skills table; every existing skill directory has both, and `gh skill install` docs live in the per-skill README.
- The task-prompt fence is tagged ```text (it is a prompt, not shell).

No CI, linter, or formatter is configured in this repo, so there is nothing to run beyond review.

## Related

This file is the canonical copy. Once it is on `main`:

- `https://openrouter.ai/skills/spawn-ori-eval` and `https://openrouter.ai/.well-known/skills/spawn-ori-eval/SKILL.md` start resolving — both proxy this repo's `raw.githubusercontent.com` path, so no copy lives in the website.
- The MCP `view-skills` tool fetches this file from GitHub per call (edge-cached), so there is no second copy to drift.

This PR is therefore the only thing gating those URLs; the website side is already merged: https://github.com/OpenRouterTeam/openrouter-web/pull/30860 (MCP registration, the `/ori/eval` agent CTA, markdown rendering of `/ori/eval`, `/llms.txt` discovery).


Link to Devin session: https://openrouter.devinenterprise.com/sessions/292c91da5de543cda4f592193529102c
Requested by: @jackyliang-openrouter