### PR TITLE
docs: refresh spawn-ori-eval with real spawn command, defer Q&A to create-eval

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -89,4 +89,4 @@ not create or modify anything outside the top-level evals directory.
 | Long silence on the first run | Template fetch, roughly 30s. Wait before retrying. |
 | Ori reports a model id as unavailable | Have it look the id up again rather than substituting one from memory. |
 | The eval file landed outside `evals/` | Move it and re-run `ori eval` against the new path. |
-| Run exceeds your timeout | It was backgrounded. Keep polling the log, do not re-spawn. |
+| Run exceeds your timeout | The run is still going in the terminal. Do not re-spawn. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -5,7 +5,7 @@ description: Spawn Ori as a subprocess to run a model eval on a pinned harness a
 
 # Spawn Ori Eval
 
-You are not going to write this eval. You are going to install Ori if needed, scope the eval with the user, hand it to a headless Ori run, and relay what comes back.
+You are not going to write this eval. You are going to install Ori if needed, scope the eval with the user, hand it to an Ori run, and relay what comes back.
 
 That split is deliberate. Ori pins the harness and the model that author and grade the eval, so the bench is identical no matter which coding agent the user happens to be driving. An eval you author yourself is not reproducible, and a score change has to mean the user's agent changed, not the environment.
 
@@ -19,7 +19,7 @@ Run these in order. Do not skip ahead on a failure.
 
    It installs to `~/.local/bin`, which is often not on PATH in a non-login shell. Re-check with `~/.local/bin/ori --version` before reporting failure.
 
-2. Auth: `~/.ori/credentials.json` must exist. It is created by `ori login` and scoped specifically to Ori; do not substitute a raw `OPENROUTER_API_KEY`. If it is missing, STOP and hand it back to the user. `ori login` opens a browser and you cannot complete it. Tell them to run it themselves. In Claude Code, tell them to type `! ori login`.
+2. Auth: recommend `ori login`, which stores an Ori-scoped credential at `~/.ori/credentials.json`. Do not tell the user to export a raw `OPENROUTER_API_KEY`. If the credential is missing, STOP and hand it back to the user. `ori login` opens a browser and you cannot complete it. Tell them to run it themselves. In Claude Code, tell them to type `! ori login`.
 
 3. `command -v bun`. Ori executes `*.eval.ts` through Bun.
 
@@ -40,29 +40,31 @@ Tell the user these answers are frozen once the run starts.
 
 ## 3. Spawn it
 
-<!-- TODO(launch): placeholder — the headless invocation devex is not final. Replace this command block with the real one before launch. -->
-
 ```bash
-# PLACEHOLDER — headless invocation command TBD, update before launch
-<ori-headless-invocation> "$(cat /tmp/ori-task.txt)" > /tmp/ori-run.log 2>&1 &
+ori code -p "<task>"
+# For a long prompt:
+ori code --prompt-file /tmp/ori-task.txt
 ```
 
-- Background it. A real run outlasts most agents' foreground command timeout. Poll the log; do not block.
+- `-p` and `--prompt-file` are mutually exclusive. Positional prompts are rejected.
+- `-p` is currently available only in the alpha channel. Stable `0.2.3` does not include it; update with `ori update --alpha` or run with `ORI_CHANNEL=alpha`.
+- `ori code` requires a TTY. Non-interactive stdout exits 1 with "`ori code` is interactive and needs a terminal"; this is tracked as ORI-814. Run it in a terminal/PTY until the non-interactive exit mode ships.
 - Do NOT pass `--model` or `--harness`. Overriding the pin destroys the reproducibility that is the only reason to use Ori.
 - Run from the repo root so Ori can read the real prompts.
-- One invocation. Do not loop the headless run once per candidate model. Comparing models is `ori eval`'s job, not yours.
+- One invocation. Do not loop the run once per candidate model. Comparing models is `ori eval`'s job, not yours.
 - The first `ori` run on a machine creates `~/.ori/global` and fetches templates over the network. Expect a pause of roughly 30 seconds and do not treat it as a hang.
 
 ## 4. The task prompt
 
-Write this to `/tmp/ori-task.txt` — the file the section 3 command cats — and fill every angle-bracket slot. If you use a different path, use it in the spawn command too; an unwritten path cats to an empty prompt and Ori does nothing.
+Write this to `/tmp/ori-task.txt` — the file used by the section 3 command — and fill every angle-bracket slot. If you use a different path, use it in the spawn command too; an unwritten path produces an empty prompt and Ori does nothing.
 
 ```text
-Use the writing-evals skill.
+Use the create-eval skill.
 
 Feature under test: <feature name>
 Real prompt and call site: <paths>. Read these first and use the actual
 production prompt, not a paraphrase.
+The surface to eval is already chosen; do not ask which surface to eval.
 Model in production today: <model id> at <file:line>. Include it as the
 baseline row.
 
@@ -77,8 +79,8 @@ Cases must span: fully covered by context, partially covered, not covered at
 all, adversarial pressure for something the context does not support, and
 <domain-specific cases>.
 
-Write the eval to evals/<feature>.eval.ts and run it with ori eval. Do not
-create or modify anything outside the evals directory.
+Write the eval to evals/<feature>/<name>.eval.ts and run it with ori eval. Do
+not create or modify anything outside the top-level evals directory.
 
 Report a ranked table, state plainly whether anything beats the production model
 by enough to justify a swap, and quote 2 or 3 concrete failures from the losing
@@ -97,7 +99,11 @@ models.
 ## 6. After the run
 
 - The `*.eval.ts` file is the durable artifact. Tell the user to commit it.
-- Re-runs do not need a full headless run. `ori eval evals/<feature>.eval.ts` is enough and much cheaper. This is what turns a one-off answer into a guardrail.
+- Re-runs do not need a full Ori run. `ori eval evals/<feature>/<name>.eval.ts` is enough and much cheaper. This is what turns a one-off answer into a guardrail.
+- Use `ori eval --report <path>` for shareable Markdown reports.
+- Use `--baseline last|best|model:<slug>` to choose the comparison baseline; history is stored in `.ori/eval/history.jsonl`.
+- Use `run.toCostAtMost` and `run.toFinishWithin` for cost and time bounds.
+- Use `candidateModels` with `assertModelIsLive` to validate candidate availability, and `--list --allow-no-key` when listing models without authentication.
 - Offer to wire `ori eval` into CI so a worse agent fails the build.
 - Relay the full table, the ship or no-ship call, and the quoted failures. Do not summarize away the failure quotes; they are the most useful output.
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -5,7 +5,7 @@ description: Spawn Ori as a subprocess to run a model eval on a pinned harness a
 
 # Spawn Ori Eval
 
-You are not going to write this eval. You are going to install Ori if needed, scope the eval with the user, hand it to an Ori run, and relay what comes back.
+You are not going to write this eval. You are going to install Ori if needed, hand the request to an Ori run, and relay what comes back.
 
 That split is deliberate. Ori pins the harness and the model that author and grade the eval, so the bench is identical no matter which coding agent the user happens to be driving. An eval you author yourself is not reproducible, and a score change has to mean the user's agent changed, not the environment.
 
@@ -25,18 +25,9 @@ Run these in order. Do not skip ahead on a failure.
 
 Never print, echo, or log the contents of `credentials.json` or any other value you read out of a `.env` file or config while searching. Name the key, never the value: `OPENAI_API_KEY at .env:4`, not what it is set to.
 
-## 2. Scope it before you spawn
+## 2. Keep the Q&A in `create-eval`
 
-Ori runs headless. Once it starts it cannot ask the user anything, so every decision has to be made now.
-
-1. Find every model call site in the repo. Search for `openrouter`, `anthropic`, `openai`, `chat.completions`, `messages.create`, `model=`, `MODEL`, and model ids in config files and `.env` keys.
-2. Report what you found, grouped by feature, with file and line.
-3. Ask the user to pick exactly ONE feature. A repo with a support bot, a summarizer, and a classifier needs three separate evals, not one blended score.
-4. Ask what the model needs to be good at, in their own words. Do not offer four canned options; the real answer is usually a sentence.
-5. Ask for a cost ceiling per call.
-6. Confirm which model is in production today. It becomes the baseline row.
-
-Tell the user these answers are frozen once the run starts.
+`spawn-ori-eval` does not do the scoping interview. Ori's `create-eval` skill already asks which surface to eval, what it needs to be good at, what real data to use, the cost ceiling, and the baseline model. This skill just hands that request off.
 
 ## 3. Spawn it
 
@@ -49,6 +40,7 @@ ori code --prompt-file /tmp/ori-task.txt
 - `-p` and `--prompt-file` are mutually exclusive. Positional prompts are rejected.
 - `-p` is currently available only in the alpha channel. Stable `0.2.3` does not include it; update with `ori update --alpha` or run with `ORI_CHANNEL=alpha`.
 - `ori code` requires a TTY. Non-interactive stdout exits 1 with "`ori code` is interactive and needs a terminal"; this is tracked as ORI-814. Run it in a terminal/PTY until the non-interactive exit mode ships.
+- Interactive Q&A inside a headless run depends on ORI-814's headless mode exposing a question/answer channel; until then, `ori code` stays interactive-terminal only.
 - Do NOT pass `--model` or `--harness`. Overriding the pin destroys the reproducibility that is the only reason to use Ori.
 - Run from the repo root so Ori can read the real prompts.
 - One invocation. Do not loop the run once per candidate model. Comparing models is `ori eval`'s job, not yours.
@@ -61,30 +53,11 @@ Write this to `/tmp/ori-task.txt` — the file used by the section 3 command —
 ```text
 Use the create-eval skill.
 
-Feature under test: <feature name>
-Real prompt and call site: <paths>. Read these first and use the actual
-production prompt, not a paraphrase.
-The surface to eval is already chosen; do not ask which surface to eval.
-Model in production today: <model id> at <file:line>. Include it as the
-baseline row.
-
-Rank primarily on: <the user's words, verbatim>
-Secondary axes, reported as tiebreakers: <axes>
-Hard gate: fail any model above <N> per call and mark it as a cost failure.
-
-Compare the production model plus 4 or 5 other currently available models. Look
-up real per-token pricing. Do not recall model ids from memory.
-
-Cases must span: fully covered by context, partially covered, not covered at
-all, adversarial pressure for something the context does not support, and
-<domain-specific cases>.
+User request: <verbatim request>
+Repo context pointers: <paths>. Read these first.
 
 Write the eval to evals/<feature>/<name>.eval.ts and run it with ori eval. Do
 not create or modify anything outside the top-level evals directory.
-
-Report a ranked table, state plainly whether anything beats the production model
-by enough to justify a swap, and quote 2 or 3 concrete failures from the losing
-models.
 ```
 
 ## 5. Never do these

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -40,7 +40,7 @@ ori code --prompt-file /tmp/ori-task.txt
 - `-p` and `--prompt-file` are mutually exclusive. Positional prompts are rejected.
 - `-p` is currently available only in the alpha channel. Stable `0.2.3` does not include it; update with `ori update --alpha` or run with `ORI_CHANNEL=alpha`.
 - `ori code` requires a TTY. Non-interactive stdout exits 1 with "`ori code` is interactive and needs a terminal"; this is tracked as ORI-814. Run it in a terminal/PTY until the non-interactive exit mode ships.
-- Interactive Q&A inside a headless run depends on ORI-814's headless mode exposing a question/answer channel; until then, `ori code` stays interactive-terminal only.
+- Interactive Q&A depends on ORI-814's headless mode exposing a question/answer channel; until then, `ori code` stays interactive-terminal only.
 - Do NOT pass `--model` or `--harness`. Overriding the pin destroys the reproducibility that is the only reason to use Ori.
 - Run from the repo root so Ori can read the real prompts.
 - One invocation. Do not loop the run once per candidate model. Comparing models is `ori eval`'s job, not yours.
@@ -63,7 +63,7 @@ not create or modify anything outside the top-level evals directory.
 ## 5. Never do these
 
 - **Never spawn your own subagent to "do an eval."** It produces a plausible table with no pinned bench behind it, which is worse than no answer.
-- **Never write the eval yourself.** Ori's `writing-evals` skill fires automatically inside the headless run.
+- **Never write the eval yourself.** Ori's `create-eval` skill fires automatically inside the Ori run.
 - **Never put the eval in the repo's existing test framework.** `ori eval` discovers `*.eval.ts` only. A pytest, vitest, or Go test file silently never runs, and silence reads as passing.
 - **Never hand-roll raw API calls and present the numbers as an Ori eval.** If you measure something another way, label it clearly as such.
 - **Never name model ids or prices from memory.** They go stale between releases.
@@ -76,7 +76,7 @@ not create or modify anything outside the top-level evals directory.
 - Use `ori eval --report <path>` for shareable Markdown reports.
 - Use `--baseline last|best|model:<slug>` to choose the comparison baseline; history is stored in `.ori/eval/history.jsonl`.
 - Use `run.toCostAtMost` and `run.toFinishWithin` for cost and time bounds.
-- Use `candidateModels` with `assertModelIsLive` to validate candidate availability, and `--list --allow-no-key` when listing models without authentication.
+- Use `candidateModels` with `assertModelIsLive` to validate candidate availability, and `--list --allow-no-key` to list discovered evals without an API key.
 - Offer to wire `ori eval` into CI so a worse agent fails the build.
 - Relay the full table, the ship or no-ship call, and the quoted failures. Do not summarize away the failure quotes; they are the most useful output.
 


### PR DESCRIPTION
## Summary

Post-#99 refresh of `spawn-ori-eval/SKILL.md`, now live-served at openrouter.ai's skill URL, so it stops telling agents to run `PLACEHOLDER`:

- **Real spawn command** (verified against ori main and the shipped `0.2.3-alpha+f591153` binary): `ori code -p "<task>"` / `ori code --prompt-file /tmp/ori-task.txt`. Flags are mutually exclusive; positional prompts rejected. Documented caveats: `-p` is alpha-channel only today (`ori update --alpha`), and `ori code` requires a TTY — non-interactive stdout exits 1 (tracked as ORI-814).
- **Q&A moved out of this skill** (Jacky's direction): the §2 scoping interview (pick feature, criteria, cost ceiling, baseline) is removed. Ori's `create-eval` skill owns all questions; this skill only installs ori, checks auth, spawns, and relays results. The task prompt shrinks to the user's verbatim request + repo pointers.
- **Auth**: recommend `ori login` (Ori-scoped credential), not exporting a raw `OPENROUTER_API_KEY`.
- **Eval location**: `evals/<feature>/<name>.eval.ts` — top-level `evals/` dir segmented per feature (decision from #proj-ori).
- **Shipped flags replace prose**: `ori eval --report <path>`, `--baseline last|best|model:<slug>` + `.ori/eval/history.jsonl`, `run.toCostAtMost`/`run.toFinishWithin`, `candidateModels`/`assertModelIsLive`, `--list --allow-no-key`.
- Stale `writing-evals` name updated to `create-eval`.

Companion PR updates the create-eval skill's eval placement in OpenRouterIncubator/ori.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/a286503f70984c63b5157c68ddbee653
Requested by: @jackyliang-openrouter