### PR TITLE
docs: spawn-ori-eval assumes headless one-shot mode (ORI-814)

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -32,14 +32,14 @@ Never print, echo, or log the contents of `credentials.json` or any other value 
 ## 3. Spawn it
 
 ```bash
-ori code -p "<task>"
+ori code -p "<task>" --output jsonl
 # For a long prompt:
-ori code --prompt-file /tmp/ori-task.txt
+ori code --prompt-file /tmp/ori-task.txt --output jsonl
 ```
 
 - `-p` and `--prompt-file` are mutually exclusive. Positional prompts are rejected.
-- `ori code -p "<task>"` runs without a TTY and exits when the prompt completes: exit code 0 on success, nonzero on failure. With stdout piped it streams NDJSON — one `{"kind":"event","event":...}` line per runtime event, then a final `{"kind":"result","ok":...,"sessionId":"..."}` line. Ori's reply text is the concatenated `assistant.text.delta` payloads.
-- Questions the `create-eval` skill asks land in that stream (usually as the run's final reply text). The run never blocks on them. Answer by resuming the same session with the `sessionId` from the result line: `ori code --session <sessionId> -p "<answer>"`, and keep chaining until the eval is written and run.
+- `ori code -p "<task>"` runs without a TTY and exits when the prompt completes: exit code 0 on success, nonzero on failure. A plain piped run streams Ori's reply as prose. Add `--output jsonl` for the structured stream — one `{"kind":"event","event":...}` line per runtime event, then a final `{"kind":"result","ok":...,"sessionId":"..."}` line; Ori's reply text is the concatenated `assistant.text.delta` payloads. Prefer `--output jsonl`: it is the only stream that carries the `sessionId`.
+- Questions the `create-eval` skill asks land in that stream (usually as the run's final reply text; with `--output jsonl`, also as `elicitation.requested` events, auto-declined so the run never blocks). Answer by resuming the same session with the `sessionId` from the result line: `ori code --session <sessionId> -p "<answer>" --output jsonl`, and keep chaining until the eval is written and run.
 - Do NOT pass `--model` or `--harness`. Overriding the pin destroys the reproducibility that is the only reason to use Ori.
 - Run from the repo root so Ori can read the real prompts.
 - One invocation. Do not loop the run once per candidate model. Comparing models is `ori eval`'s job, not yours.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -38,9 +38,8 @@ ori code --prompt-file /tmp/ori-task.txt
 ```
 
 - `-p` and `--prompt-file` are mutually exclusive. Positional prompts are rejected.
-- `-p` is currently available only in the alpha channel. Stable `0.2.3` does not include it; update with `ori update --alpha` or run with `ORI_CHANNEL=alpha`.
-- `ori code` requires a TTY. Non-interactive stdout exits 1 with "`ori code` is interactive and needs a terminal"; this is tracked as ORI-814. Run it in a terminal/PTY until the non-interactive exit mode ships.
-- Interactive Q&A depends on ORI-814's headless mode exposing a question/answer channel; until then, `ori code` stays interactive-terminal only.
+- `ori code -p "<task>"` runs without a TTY, streams output to stdout, and exits when the prompt completes with exit code 0 on success or nonzero on failure.
+- Questions the `create-eval` skill asks flow through the headless run back to the calling agent; answer them there as they appear.
 - Do NOT pass `--model` or `--harness`. Overriding the pin destroys the reproducibility that is the only reason to use Ori.
 - Run from the repo root so Ori can read the real prompts.
 - One invocation. Do not loop the run once per candidate model. Comparing models is `ori eval`'s job, not yours.
@@ -63,7 +62,7 @@ not create or modify anything outside the top-level evals directory.
 ## 5. Never do these
 
 - **Never spawn your own subagent to "do an eval."** It produces a plausible table with no pinned bench behind it, which is worse than no answer.
-- **Never write the eval yourself.** Ori's `create-eval` skill fires automatically inside the Ori run.
+- **Never write the eval yourself.** Ori's `create-eval` skill fires automatically inside the run.
 - **Never put the eval in the repo's existing test framework.** `ori eval` discovers `*.eval.ts` only. A pytest, vitest, or Go test file silently never runs, and silence reads as passing.
 - **Never hand-roll raw API calls and present the numbers as an Ori eval.** If you measure something another way, label it clearly as such.
 - **Never name model ids or prices from memory.** They go stale between releases.
@@ -89,4 +88,4 @@ not create or modify anything outside the top-level evals directory.
 | Long silence on the first run | Template fetch, roughly 30s. Wait before retrying. |
 | Ori reports a model id as unavailable | Have it look the id up again rather than substituting one from memory. |
 | The eval file landed outside `evals/` | Move it and re-run `ori eval` against the new path. |
-| Run exceeds your timeout | The run is still going in the terminal. Do not re-spawn. |
+| Run exceeds your timeout | It is still running in the background. Keep polling output; do not re-spawn. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -38,8 +38,8 @@ ori code --prompt-file /tmp/ori-task.txt
 ```
 
 - `-p` and `--prompt-file` are mutually exclusive. Positional prompts are rejected.
-- `ori code -p "<task>"` runs without a TTY, streams output to stdout, and exits when the prompt completes with exit code 0 on success or nonzero on failure.
-- Questions the `create-eval` skill asks flow through the headless run back to the calling agent; answer them there as they appear.
+- `ori code -p "<task>"` runs without a TTY and exits when the prompt completes: exit code 0 on success, nonzero on failure. With stdout piped it streams NDJSON — one `{"kind":"event","event":...}` line per runtime event, then a final `{"kind":"result","ok":...,"sessionId":"..."}` line. Ori's reply text is the concatenated `assistant.text.delta` payloads.
+- Questions the `create-eval` skill asks land in that stream (usually as the run's final reply text). The run never blocks on them. Answer by resuming the same session with the `sessionId` from the result line: `ori code --session <sessionId> -p "<answer>"`, and keep chaining until the eval is written and run.
 - Do NOT pass `--model` or `--harness`. Overriding the pin destroys the reproducibility that is the only reason to use Ori.
 - Run from the repo root so Ori can read the real prompts.
 - One invocation. Do not loop the run once per candidate model. Comparing models is `ori eval`'s job, not yours.
@@ -88,4 +88,4 @@ not create or modify anything outside the top-level evals directory.
 | Long silence on the first run | Template fetch, roughly 30s. Wait before retrying. |
 | Ori reports a model id as unavailable | Have it look the id up again rather than substituting one from memory. |
 | The eval file landed outside `evals/` | Move it and re-run `ori eval` against the new path. |
-| Run exceeds your timeout | It is still running in the background. Keep polling output; do not re-spawn. |
+| Run exceeds your timeout | The process may still be running. Keep reading its stdout until the `{"kind":"result",...}` line arrives; do not re-spawn. |


### PR DESCRIPTION
## Summary

Rewrites `spawn-ori-eval`'s §3 caveats to assume ORI-814 (headless one-shot mode) has shipped, per Jacky — he's implementing it in a parallel session. **Draft until ORI-814 actually lands**; merging earlier would make the live skill (served at openrouter.ai/skills/spawn-ori-eval) describe behavior that errors out today.

- Removed: alpha-channel-only note, TTY-required note, ORI-814 tracking caveat.
- Added: `ori code -p "<task>"` runs without a TTY, streams to stdout, exits 0/nonzero on completion; `create-eval`'s questions flow through the headless run to the calling agent.
- §7 timeout troubleshooting row updated to background/poll guidance to match.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/a286503f70984c63b5157c68ddbee653
Requested by: @jackyliang-openrouter