### PR TITLE
docs: spawn-ori-eval must not ask the user anything before spawning

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -29,6 +29,8 @@ Never print, echo, or log the contents of `credentials.json` or any other value 
 
 `spawn-ori-eval` does not do the scoping interview. Ori's `create-eval` skill already asks which surface to eval, what it needs to be good at, what real data to use, the cost ceiling, and the baseline model. This skill just hands that request off.
 
+Do not ask the user anything before spawning — not even "what do you want to eval?". If the request is vague or empty, spawn anyway and pass through whatever the user said verbatim; `create-eval` asks its questions inside the Ori run.
+
 ## 3. Spawn it
 
 ```bash


### PR DESCRIPTION
## Summary

Jacky hit this live: with an empty request ("spawn ori eval"), the agent asked "What do you want to eval?" before spawning. That question belongs inside the Ori run (create-eval), not outside. Adds one explicit rule to §2:

> Do not ask the user anything before spawning — not even "what do you want to eval?". If the request is vague or empty, spawn anyway and pass through whatever the user said verbatim; `create-eval` asks its questions inside the Ori run.

Live immediately on merge (skill is served from GitHub raw, 10-min edge cache).

Link to Devin session: https://openrouter.devinenterprise.com/sessions/a286503f70984c63b5157c68ddbee653
Requested by: @jackyliang-openrouter