### PR TITLE
docs(spawn-ori-eval): close every run with a cost summary (ORI-907)

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -129,6 +129,11 @@ not create or modify anything outside the top-level evals directory.
 - Use `candidateModels` with `assertModelIsLive` to validate candidate availability, and `--list --allow-no-key` to list discovered evals without an API key.
 - Offer to wire `ori eval` into CI so a worse agent fails the build.
 - Relay the full table, the ship or no-ship call, and the quoted failures. Do not summarize away the failure quotes; they are the most useful output.
+- **Close with what the run cost.** One line, three parts: Ori's own session (read `usage.costUsd` off the final `turn.succeeded` event in the jsonl stream), the eval's model calls, and the judge (both from the report's Judging table or `data.results`). The authoring session usually dwarfs the eval — say so, because it is also the part a re-run never pays again:
+
+  > This cost about $28.20 total: $27.69 for Ori's one-time authoring session, $0.46 for the eval's model calls, $0.05 for judging. Re-running the eval costs only ~$0.51.
+
+  Never invent a figure — anything the stream or report did not carry is "unmeasured", not $0.
 
 ## 9. If something goes wrong
 


### PR DESCRIPTION
## Why

Nobody learns what a spawn-ori-eval run cost. In yesterday's e2e run the authoring session alone was **$27.69** (`turn.succeeded.payload.usage.costUsd`) against ~$0.46 of eval spend — both invisible unless you parse the stream. Requested by Jacky during QA.

## What

One bullet added to §8: the calling agent MUST close with a one-line cost summary split three ways — Ori's authoring session (from the final `turn.succeeded` event), the eval's model calls, and the judge (from the report's Judging table). It must note the authoring cost is one-time (re-runs only pay the eval), and report missing figures as "unmeasured", never $0.

Linear: [ORI-907](https://linear.app/openrouter/issue/ORI-907)