### PR TITLE
feat: add install-ori-harness skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | [openrouter-analytics-query](skills/openrouter-analytics-query/README.md) | Constructing and executing analytics queries against the OpenRouter API — full parameter reference for metrics, dimensions, filters, time ranges, ordering, and pagination |
 | [openrouter-generations](skills/openrouter-generations/README.md) | Inspecting individual OpenRouter generations — request metadata (cost, latency, tokens, model, provider routing) and stored prompt/completion content |
 | [spawn-ori-eval](skills/spawn-ori-eval/README.md) | Delegating model evals to [Ori](https://openrouter.ai/ori/code) — spawning a headless Ori run so the eval is authored and graded on a pinned harness and model, then relaying the ranked results |
+| [install-ori-harness](skills/install-ori-harness/README.md) | Installing Ori and running an existing coding agent through OpenRouter with OAuth, model selection, upgrades, and setup verification |
 
 ## Environment
 

--- a/skills/install-ori-harness/README.md
+++ b/skills/install-ori-harness/README.md
@@ -1,0 +1,25 @@
+# install-ori-harness
+
+Install Ori and run the user's existing coding agent through OpenRouter with OAuth sign-in, model selection, upgrades, and a verified setup.
+
+## Install
+
+With the [GitHub CLI](https://cli.github.com/) (v2.90.0+):
+
+```bash
+gh skill install OpenRouterTeam/skills install-ori-harness
+```
+
+Works with Claude Code, Cursor, Codex, OpenCode, Gemini CLI, Windsurf, and [many more agents](https://cli.github.com/manual/gh_skill_install). Add `--scope user` to install across every project for your current agent, or `--agent claude-code` to target a specific agent.
+
+For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) see the [root README](../../README.md#installing).
+
+## What it covers
+
+See [SKILL.md](SKILL.md) for the full reference, including:
+
+- Installing Ori with the official installer and checking the CLI
+- Signing in with OpenRouter OAuth, including the headless browser flow
+- Running Claude Code, Codex, OpenCode, or Hermes through Ori
+- Forwarding normal agent arguments and selecting any OpenRouter model
+- Upgrading Ori and confirming a harmless agent request reaches OpenRouter

--- a/skills/install-ori-harness/README.md
+++ b/skills/install-ori-harness/README.md
@@ -22,4 +22,5 @@ See [SKILL.md](SKILL.md) for the full reference, including:
 - Signing in with OpenRouter OAuth, including the headless browser flow
 - Running Claude Code, Codex, OpenCode, or Hermes through Ori
 - Forwarding normal agent arguments and selecting any OpenRouter model
-- Upgrading Ori and confirming a harmless agent request reaches OpenRouter
+- Upgrading Ori with `ori update`
+- Confirming a harmless agent request reaches OpenRouter

--- a/skills/install-ori-harness/SKILL.md
+++ b/skills/install-ori-harness/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: install-ori-harness
+description: Install Ori and run the user's existing coding agent CLI through Ori on OpenRouter, with OAuth sign-in, model selection, upgrades, and install verification.
+---
+
+# Install and run Ori Harness
+
+Use this recipe when the user wants to install Ori, run an existing coding
+agent through Ori, sign in to Ori, upgrade Ori, or select an OpenRouter model
+for a local agent. Do not use it for model evaluations, plain unit tests, or
+when the user only wants to run an already-installed agent directly without
+Ori.
+
+## 1. Install Ori
+
+Run the official installer:
+
+```sh
+curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh
+```
+
+The installer puts the `ori` executable in the user's local install location.
+Do not use `sudo` unless the user explicitly chooses a system-wide install
+location.
+
+## 2. Verify the CLI
+
+Run:
+
+```sh
+ori --version
+```
+
+The command must print a version and exit successfully. If the shell cannot
+find `ori`, inspect the installer's reported directory and ensure the user's
+local binary directory is on `PATH`, then start a new shell or update `PATH`
+before continuing.
+
+## 3. Sign in with OpenRouter OAuth
+
+Run:
+
+```sh
+ori login
+```
+
+Ori opens the user's browser for OAuth sign-in with their existing OpenRouter
+account and stores the resulting credential for the CLI. The user does not
+need to create, copy, or paste an API key. If a browser cannot open, use
+`ori login --no-browser` and give the user the printed URL.
+
+Do not ask the user to paste a key when OAuth is available. An explicitly
+exported `OPENROUTER_API_KEY` can still be used by Ori when the user already
+has one, but it is not required for this setup.
+
+## 4. Run the user's existing agent CLI
+
+Ori runs the agent CLI already installed on the user's `PATH`. It does not
+replace the user's agent or make them learn a new agent workflow. Supported
+launch commands today are:
+
+```sh
+ori claude
+ori codex
+ori opencode
+ori hermes
+```
+
+If the selected agent is missing, Ori prints the recommended install command
+and documentation link for that agent. Follow that instruction, then rerun the
+same `ori <harness>` command.
+
+Pass the user's normal agent arguments after the Ori flags. Everything Ori does
+not consume is forwarded to the agent unchanged. For example:
+
+```sh
+ori claude -p "Review the authentication changes"
+ori codex --full-auto
+ori opencode
+```
+
+## 5. Choose any OpenRouter model
+
+Use `--model` with any valid OpenRouter model id:
+
+```sh
+ori claude --model anthropic/claude-sonnet-4
+ori codex --model openai/gpt-5
+ori hermes --model google/gemini-2.5-pro
+```
+
+The model value is routed through OpenRouter. Keep the user's existing agent
+arguments after the Ori flags.
+
+## 6. Upgrade Ori
+
+Upgrade an installed release with:
+
+```sh
+ori update
+```
+
+Then verify the active version again:
+
+```sh
+ori --version
+```
+
+Do not use `ori update` from a source checkout as a substitute for installing
+the released CLI.
+
+## 7. Confirm the setup works
+
+After sign-in, run the selected agent with a harmless prompt that proves the
+request reaches OpenRouter:
+
+```sh
+ori claude --model openrouter/auto -p "Reply with exactly: Ori is connected"
+```
+
+Use the equivalent `ori codex`, `ori opencode`, or `ori hermes` command if the
+user chose another agent. Confirm that the agent starts, the prompt completes,
+and the response is returned. If the agent is missing, authentication fails,
+or the model id is rejected, report the exact command output and fix that
+specific setup issue before claiming the install worked.

--- a/skills/install-ori-harness/SKILL.md
+++ b/skills/install-ori-harness/SKILL.md
@@ -84,9 +84,9 @@ ori opencode
 Use `--model` with any valid OpenRouter model id:
 
 ```sh
-ori claude --model anthropic/claude-sonnet-4
-ori codex --model openai/gpt-5
-ori hermes --model google/gemini-2.5-pro
+ori claude --model claude-opus-latest
+ori codex --model gpt-5.2
+ori hermes --model gemini-3-pro
 ```
 
 The model value is routed through OpenRouter. Keep the user's existing agent


### PR DESCRIPTION
## Summary

Adds `skills/install-ori-harness/SKILL.md`, the recipe that takes an agent from "the user asked me to install Ori" to a verified working harness run. It is the second consumer of the same publish path as `spawn-ori-eval`: the OpenRouter MCP's new `install-ori-harness` tool fetches this exact file from `raw.githubusercontent.com` at call time, and `/ori/harness` points humans at `openrouter.ai/skills/install-ori-harness`. Merging this first is what makes the tool return something (see OpenRouterTeam/openrouter-web for the tool and page).

The content is written against the CLI as it actually exists in `OpenRouterIncubator/ori`, not against the marketing page, since an agent following a wrong command gets stuck on step one. Verified against `framework/cli`:

- `ori login`, plus `ori login --no-browser` for the headless case (`commands/login/command.ts`)
- `ori claude` / `ori codex` / `ori opencode` / `ori hermes` (`coding-command-roster.ts` — note `opencode`, which the harness page's FAQ copy does not currently list)
- `--model` accepting any OpenRouter model id (`commands/agent-launch.ts`)
- `ori update`

Two things the recipe is deliberate about: OAuth is the path, so the skill tells the agent not to ask the user to paste an API key when `ori login` will do, and the last step is a real run (`-p` with a trivial prompt) rather than a version check, so "installed" means "a request reached OpenRouter" instead of "a binary exists on PATH".

Naming is still open with the Ori team (`install-ori` vs `install-ori-harness`). Renaming is cheap right now and breaking once MCP clients hardcode the tool name. Tracked in ORI-956.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/78056dd51d684cbd9972f9d0ae8bf748
Requested by: @jackyliang-openrouter