### PR TITLE
docs(spawn-ori-eval): flatten the skill into a trackable checklist with hoisted rules

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -5,64 +5,65 @@ description: Spawn Ori as a subprocess to run a model eval on a pinned harness a
 
 # Spawn Ori Eval
 
-Do not write this eval yourself. Install Ori if it is not installed. Give the request to an Ori run. Keep the user informed while Ori works. Relay the results.
+Ori writes and grades the eval on a pinned harness and model, so the bench is identical for every coding agent. You run Ori, keep the user informed, and relay the result. An eval you write yourself is not reproducible, and a score change must come from the user's agent, not from the environment.
 
-This division of work is deliberate. Ori pins the harness and the model that write and grade the eval. Thus the bench is the same for every coding agent. An eval that you write yourself is not reproducible. A score change must show a change in the user's agent, not a change in the environment.
+## Steps
 
-Your task is the part that Ori cannot do. You are the user's only connection to the run. Tell the user what you started. Give Ori's questions to the user. Append the user's answers to the task file and restart the run. Relay the full result.
+Do these in order. Each one is a single action.
 
-## Step summary
+1. Run `command -v ori`, and if it is missing run `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`.
+2. If the lookup still fails, run `~/.local/bin/ori --version`, and if that also fails, stop and report it.
+3. Confirm `~/.ori/credentials.json` exists, and if it does not, stop and tell the user to run `ori login`.
+4. Run `command -v bun`, and if it is missing, stop and tell the user to install Bun, which Ori uses to execute `*.eval.ts`.
+5. Read the eval surface by running `ori eval -h` and `ori eval skill`, falling back to `ori skills get create-eval` if the second errors, and continue to step 6 even if both error.
+6. If you installed the binary, tell the user it is at `~/.local/bin/ori`.
+7. Tell the user that a separate agent will pick a target, write an eval file under `evals/`, and score the models, describing the run from what you read in step 5 rather than from memory.
+8. Tell the user it takes roughly 10 to 30 minutes and spends real money that may exceed the credit on their key.
+9. Tell the user they will get a scored table, that Ori may ask questions, and that answering one restarts the run.
+10. Write `/tmp/ori-task.txt` from the prompt template below.
+11. Start one background run from the repo root with the start command below, and save the process ID.
+12. Read the current run's output file, `/tmp/ori-output-<n>.jsonl`, as it grows.
+13. Report each milestone as it appears, such as target picked, eval written, model 2 of 3 running.
+14. Kill the saved process ID the moment a question appears, meaning an `elicitation.requested` event, a `permission.requested` event, or a turn that ends on a prose question, and if the run instead finishes with no question, skip to step 19.
+15. Show the user the question's `payload.message` as plain text.
+16. Ask the user with your own question UI, one option per Ori option, with "Other" left as free text.
+17. Append the question and the user's answer to `/tmp/ori-task.txt`.
+18. Start a fresh run over the whole prompt file with the next output file number and a newly saved process ID, then return to step 12.
+19. Relay the full result table, the ship or no-ship decision, and the quoted failures.
+20. Relay Ori's cost and timing table in full.
+21. Add one row per run, including every run you stopped at a question, and a total row summing `usage.costUsd` across every `turn.succeeded` and `turn.failed` event in every run.
+22. Add one line separating the one-time authoring cost from the cheaper re-run cost.
+23. Tell the user to commit the `*.eval.ts` file.
+24. Offer to add `ori eval evals/<feature>/<name>.eval.ts` to CI.
 
-Do the steps in this sequence. Each step has a section below. The **Rules** in a section are limits that apply during that step. They are not more steps.
+## Rules
 
-1. **Do the pre-run checks** — 1a: the `ori` binary. 1b: login with `ori login`. 1c: the `bun` binary. 1d: read the eval surface.
-2. **Tell the user what will occur** — what Ori is, the time and the cost, the output, and that Ori can ask questions.
-3. **Write the task prompt file** — `/tmp/ori-task.txt`, with the user's request unchanged, the repo paths, and the `evals/` target.
-4. **Start one Ori run** — `ori code --prompt-file … --output jsonl`.
-5. **Monitor the run** — report progress; stop at questions, ask the user, append the answer, and restart from the full prompt file.
-6. **Relay the result** — the full table, the ship or no-ship decision, the quoted failures, and the cost and timing breakdown.
-7. **Keep the eval** — commit the `*.eval.ts` file, tell the user about `ori eval <file>` re-runs, offer CI setup.
+These hold for the whole run.
 
-If there is a problem, refer to **Troubleshooting** at the end. The **Hard rules** section after the steps applies to all steps.
+- Never write the eval yourself and never delegate it to your own subagent. Ori's `create-eval` skill runs automatically inside the run.
+- Never pass `--model` or `--harness`. They remove the pin, which is the only reason to use Ori.
+- Always pass `--prompt-file`. The `-p` flag works but never use it here, because a one-time string cannot carry state across a restart, and a bare positional prompt is rejected outright.
+- Run one Ori process at a time, never one per candidate model. `ori eval` is what compares models.
+- Treat `/tmp/ori-task.txt` as the only state. Append every later message to it, resend the whole file on every restart, never use `--session`, and never split the history into separate answer files.
+- Never ask the user what to eval before the run. Ori's interview covers the surface, success criteria, real data, cost limit, and baseline model. Pass a vague or empty request through unchanged.
+- Never answer Ori's question or accept a permission request on the user's behalf. If you cannot reach the user, stop and wait. A guessed target produces an invalid eval that looks correct.
+- Never go silent. An unreported question and 25 minutes without a progress report both look like a stopped run.
+- Never invent a number. A turn with no reported cost is unmeasured, not zero, and you say so rather than estimating.
+- Never name a winner unless the production model is in the table. "No change" is a valid result.
+- Never give model ids or prices from memory. Check live prices on OpenRouter.
+- Never tell the user to export a raw `OPENROUTER_API_KEY`. The `ori login` command is the supported path.
+- Never paste step 5's output to the user. You read it, they did not ask for it.
+- Never print a secret value from `credentials.json`, a `.env` file, or a config file. Name the key and its location only, such as `OPENAI_API_KEY at .env:4`.
+- Never put the eval outside the top-level `evals/` directory or inside the repo's own test framework. `ori eval` finds `*.eval.ts` files only, so a pytest, vitest, or Go test file silently never runs.
+- Never present raw API calls as an Ori eval. If you measure another way, label it clearly.
+- Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", "harness", "elicitation", "correlationId", "the result line", and "stdout".
+- Never copy CLI details into this skill or into text for the user. Re-read what step 5 printed for run options, reports, baselines, timeouts, and the eval-file API, because the CLI changes and copies go stale.
 
-## Step 1: Do the pre-run checks
+## Reference
 
-Do these checks in this sequence. If 1a, 1b or 1c fails, stop. Do not continue to the next check. Check 1d never stops the task.
+### Prompt template
 
-- **1a — Binary.** Run `command -v ori`. If `ori` is not installed, run `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`. The installer puts `ori` in `~/.local/bin`. This directory is frequently not on PATH in a non-login shell. Run `~/.local/bin/ori --version` before you report a failure.
-- **1b — Login.** Tell the user to run `ori login`. The command keeps an Ori credential in `~/.ori/credentials.json`. If the credential is missing, STOP. You cannot complete the login. The command opens a browser. Tell the user to run it. In Claude Code, tell the user to type `! ori login`.
-- **1c — Bun.** Run `command -v bun`. Ori runs `*.eval.ts` files with Bun.
-- **1d — The eval surface.** Run `ori eval -h` and `ori eval skill`. Read both. The guide is what Ori follows inside the run, so it tells you what the run will do and which questions it will ask. If `ori eval skill` errors, run `ori skills get create-eval`. If both error, go to step 2 anyway.
-
-**Rules for this step:**
-
-- Do not tell the user to export a raw `OPENROUTER_API_KEY`. The `ori login` command is the supported procedure.
-- Do not paste 1d's output to the user. You read it, they did not ask for it.
-- Do not show, print, or log the contents of `credentials.json`. Do not show a value that you read from a `.env` file or a config file. Give the name of the key only. Example: say `OPENAI_API_KEY at .env:4`. Do not say the value.
-
-## Step 2: Tell the user what will occur
-
-Before you start the run, tell the user what will occur. Use simple language. Many tool calls with no explanation is the most frequent complaint about this skill.
-
-Describe the run from what you read in 1d, not from memory.
-
-Tell the user these points. Use your own words. Do not use the terms in the rule below.
-
-- **What Ori is.** A different agent that writes and runs the eval. It has its own pinned harness and model.
-- **What Ori will do.** Select what to measure, write a `*.eval.ts` file in `evals/`, and score the models.
-- **The cost.** Approximately 10 to 30 minutes. How much it costs depends on how extensive the eval run is and how large the codebase is. Say this before the run, not after. The entire run may exceed how much you've added to the API key credit you added when you authed.
-- **The output.** A scored table that compares the models.
-- **Questions are possible.** Tell the user that you will bring each question to them and may restart the run after they answer. Then the interruption in step 5 is expected, not unexpected.
-- **What you installed.** If you installed the `ori` binary, tell the user its location: `~/.local/bin/ori`.
-
-**Rules for this step:**
-
-- **Do not ask the user questions before you start the run.** Do not ask "what do you want to eval?". Ori's `create-eval` skill asks the scope questions in the run: the surface, the success criteria, the real data, the cost limit, and the baseline model. If the request is not clear or is empty, start the run. Send the user's words unchanged. But you must not stay silent for the full run: when Ori asks a question, you MUST give it to the user (step 5). Ori owns the interview. You own the user.
-- **Do not use this skill's internal terms in text that the user reads.** These terms are for you, not for the user: "pre-run", "spawn", "verbatim", "harness", "elicitation", "correlationId", "the result line", "stdout". The sentence "pre-run passes. Spawning Ori with your request verbatim" tells the user nothing.
-
-## Step 3: Write the task prompt file
-
-Write this text to `/tmp/ori-task.txt`. Step 4 uses this file. Complete each angle-bracket field:
+Fill in every angle-bracket field.
 
 ```text
 Use the create-eval skill.
@@ -74,13 +75,9 @@ Write the eval to evals/<feature>/<name>.eval.ts and run it with ori eval. Do
 not create or modify anything outside the top-level evals directory.
 ```
 
-This file is the single state record for the run. When you must send more text to Ori later (step 5, any question), append that text to this file. Then the file always contains the full instruction history, and a restarted run does not lose context.
+### Start command
 
-**Rules for this step:**
-
-- If you use a different path, use the same path in the step 4 command. A path with no file gives an empty prompt, and Ori does nothing.
-
-## Step 4: Start one Ori run
+Raise the output file number on each restart.
 
 ```bash
 ori code --prompt-file /tmp/ori-task.txt --output jsonl > /tmp/ori-output-1.jsonl 2> /tmp/ori-error-1.log &
@@ -88,108 +85,39 @@ ori_pid=$!
 printf 'Ori process: %s\n' "$ori_pid"
 ```
 
-- Always use `--prompt-file`. The `-p` flag exists and works, but do not use it here. The prompt file is the central state for the run: you append to it across the run (step 5), and a one-time `-p` string cannot keep that state. A bare positional prompt with no flag is rejected.
-- The run has no TTY. Keep the process ID. Read `/tmp/ori-output-1.jsonl` as it grows and follow step 5 when a question appears. The `--output jsonl` flag gives the structured stream: one `{"kind":"event","event":...}` line for each runtime event, then one final `{"kind":"result","ok":...,"sessionId":"..."}` line. Ori's reply text is the sequence of `assistant.text.delta` payloads. Use `--output jsonl`, not plain prose output.
+### Stream shape
 
-**Rules for this step:**
+One `{"kind":"event","event":...}` line per runtime event, then one final `{"kind":"result","ok":...,"sessionId":"..."}` line. Ori's reply text is the sequence of `assistant.text.delta` payloads. An `elicitation.requested` payload carries a `message` and `fields[]`, each field with a `name`, a `type`, and often `options`. A `permission.requested` payload carries `options`.
 
-- **Do NOT use `--model` or `--harness`.** These flags remove the pin. The pin is the reason to use Ori.
-- **Start the run from the repo root.** Then Ori can read the real prompts.
-- **Start one run only.** Do not start one run for each candidate model. The `ori eval` command compares the models, not you.
-- The first `ori` run on a machine makes `~/.ori/global` and downloads templates. This causes a pause of approximately 30 seconds. This pause is not a stopped run.
+### Cost table
 
-## Step 5: Monitor the run
+Build this yourself if Ori's reply has no table, using each turn's `turn.started` timestamp, its duration to its terminal event, and that event's cost, plus the eval's model calls and judging from the report's Judging table or from `data.results`.
 
-Report progress from the stream. Examples: Ori selected a target, Ori wrote the eval, Ori runs model 2 of 3. Do not report only "the run continues". If you are silent and don't give feedback, the user will get confused. Do not confuse the user.
+| Step | Start | Duration | Cost |
+| -- | -- | -- | -- |
+| Repo exploration | 20:26 | 2m 20s | $3.20 |
+| Run stopped at question 1 | 20:29 | 39s | $0.42 |
+| Restart and repeated exploration | 20:30 | 15m 10s | $27.69 |
+| Eval model calls | 20:46 | 2m | $0.46 |
+| Judging | 20:48 | 1m | $0.05 |
+| … |  |  |  |
+| **Total** |  | **21m 09s** | **$31.82** |
 
-The default mode does not pause for a question. Ori emits the question event, settles it immediately, and keeps going. Watch the stream and stop the process as soon as a question event appears. This is urgent. If you wait, Ori can spend real money building an eval against a target it guessed.
+Follow it with one line, for example: this cost about $31.82 across two Ori runs, and re-running the eval costs only about $0.51.
 
-- **5a — Read the event from the stream.** Read the current run's output file while it grows. An `elicitation.requested` event contains `payload.message` and `payload.fields[]`. Each field has a `name`, a `type`, and frequently `options`. A `permission.requested` event contains `payload.options`. Terminate the process with the saved process ID immediately after you see either event. Do not wait for the final result line.
-- **5b — Ask the user with your own question UI.** For example, in Claude Code, use `AskUserQuestion`. Codex, Cursor CLI, etc, have their own built-in question-asking UI. Keep Ori's options one-for-one. Keep "Other" as free text the user can type in. Change Ori's words into simple language. **Show the message first. Show the picker second. Show both.** Ori's `payload.message` frequently contains context that the option labels do not contain. For the surface question, the message is a markdown table of surface and current model. Print the message as normal text in your reply. Then call your question UI below the message, with only the short option names. The table explains. The picker collects. If you compress the table into the option descriptions, the context is lost. If you remove the table, the user selects between labels with no context.
-- **5c — Append the answer and restart.** Append both the question and the user's answer to `/tmp/ori-task.txt`. Keep the question's full message and the answer in plain language. For a form, include the selected option and any free-text answer. For a permission request, include the selected option. The file must remain the full instruction history. Start a fresh run from the repo root:
-
-  ```bash
-  ori code --prompt-file /tmp/ori-task.txt --output jsonl > /tmp/ori-output-2.jsonl 2> /tmp/ori-error-2.log &
-  ori_pid=$!
-  printf 'Ori process: %s\n' "$ori_pid"
-  ```
-
-  Resend the whole prompt file every time. Save the new process ID. Give each run its own output file and raise the number each time. Step 6 needs every run's stream to report the full cost. This is a fresh run, not a live exchange. Repeat steps 5a through 5c if another question appears.
-
-**Rules for this step:**
-
-- Do not show the user the raw event or the word "elicitation".
-- **Do not invent an answer.** If you cannot contact the user, stop the run and wait. Do not guess. A guessed target makes the full eval invalid, and the result looks correct.
-- **Do not accept a permission request without the user.** Stop the run, give the request to the user, append the decision, and restart from the full prompt file.
-- **A question in plain prose** also ends the turn. Append the question and the user's answer to `/tmp/ori-task.txt`, then restart with the full prompt file. Use the same restart path for structured question events. Do not split the history into answer files.
-- **Do not use `--session` for the restart.** A new run over the full prompt file makes the answer part of the task context before Ori continues. A resumed session can retain the earlier guessed decision and can hide the answer from the prompt that drives the next run.
-
-## Step 6: Relay the result
-
-- Relay the full table, the ship or no-ship decision, and the quoted failures. Do not remove the failure quotes from your summary. They are the most useful output.
-- **End with a cost and timing breakdown table.** Ori's reply ends with a table of its steps, durations, and costs. Relay that table in full. Do not compress it to one line. Then add the rows that only you can measure, from the jsonl stream:
-  - One row for each restarted run. Include the run that stopped on a question and every fresh run after it. A restart repeats repo exploration, so include its cost and duration.
-  - A total row. A `turn.succeeded` event reports the cost of that one turn, not of the session. Sum `usage.costUsd` across every `turn.succeeded` and `turn.failed` event in every run, including runs stopped at questions and all restarts. A turn with no `usage.costUsd` is unmeasured. Do not count it as 0. Say that the total does not include it. Compute the total duration across all runs.
-
-  If Ori's reply does not contain the table, build it yourself from the stream: one row for each turn, with the timestamp of `turn.started`, the duration to the turn's terminal event, and that event's `usage.costUsd` (the cost of that one turn). Add the eval's model calls and judging from the report's Judging table or from `data.results`.
-
-  | Step | Start | Duration | Cost |
-  | -- | -- | -- | -- |
-  | Repo exploration | 20:26 | 2m 20s | $3.20 |
-  | Run stopped at question 1 | 20:29 | 39s | $0.42 |
-  | Restart and repeated exploration | 20:30 | 15m 10s | $27.69 |
-  | Eval model calls | 20:46 | 2m | $0.46 |
-  | Judging | 20:48 | 1m | $0.05 |
-  | … |  |  |  |
-  | **Total** |  | **21m 09s** | **$31.82** |
-
-- **After the table, give the re-run cost in one line.** A restart repeats the repo exploration and adds to the cost. A later `ori eval` run is cheaper because it does not repeat the authoring run:
-
-  > This cost about $31.82 total across two Ori runs: $31.31 for authoring and repeated exploration, $0.46 for the eval's model calls, and $0.05 for judging. Re-running the eval costs only ~$0.51.
-
-**Rules for this step:**
-
-- Do not invent a number. If the stream or the report does not contain a value, the value is "unmeasured". It is not $0. Do not divide a session total across steps by estimation.
-- **Do not report a winner without the production model in the table.** "No change" is a valid and useful result.
-
-## Step 7: Keep the eval
-
-- The `*.eval.ts` file is the permanent product. Tell the user to commit it.
-- A re-run does not need a full Ori run. The command `ori eval evals/<feature>/<name>.eval.ts` is sufficient and much less costly. This changes a one-time answer into a guardrail.
-- Offer to add `ori eval` to CI. Then a worse agent causes a failed build.
-- For all other data about eval runs — reports, baselines, lists, timeouts, the eval-file API — re-read 1d. Do not copy it into this skill or into text for the user. The CLI changes, and copies become incorrect.
-
-## Hard rules
-
-These rules apply to all steps:
-
-- **Do not start your own subagent to "do an eval".** You must use Ori to run the eval.
-- **Do not write the eval yourself.** Ori's `create-eval` skill starts automatically in the run.
-- **Do not put the eval in the repo's own test framework.** The `ori eval` command finds `*.eval.ts` files only. A pytest, vitest, or Go test file does not run, and no signal shows this. Silence looks like a pass.
-- **Do not make raw API calls and show the numbers as an Ori eval.** If you measure in a different way, label the result clearly.
-- **Do not give model ids or prices from memory.** You must check live model prices on OpenRouter.
-- **Do not answer Ori's questions for the user.** Stop the run, show the question, and wait for the person to select. A guessed target makes the result invalid, and the guess looks like a real answer.
-- **Do not let the run become silent.** An unreported question and 25 minutes with no progress report both look like a stopped run.
-
-## Troubleshooting
+### Troubleshooting
 
 | Symptom | Do this |
 |---|---|
 | `ori: command not found` after a good installation | Run `~/.local/bin/ori`. The installer's PATH change does not apply to the current shell. |
-| The credential is missing | Stop. Tell the user to run `ori login`. |
-| A long pause on the first run | This is the template download. It takes approximately 30 seconds. Wait before you retry. |
-| Ori reports that a model id is not available | Tell Ori to find the id again. Do not give a different id from memory. |
-| The eval file is outside `evals/` | Move the file. Run `ori eval` on the new path. |
-| The run is longer than expected | The process may still be running. Read the stream. If a question event appears, stop the process immediately. Do not wait for the final result line. |
-| Ori selected the eval's target itself, and the run produced an eval for a target nobody chose | The question event was missed in the stream, or the run was allowed to continue after it appeared. Stop the process as soon as `elicitation.requested` or `permission.requested` appears. Ask the user, append the question and the answer to `/tmp/ori-task.txt`, then restart from the full prompt file. |
-| No question arrives but the run looks stopped | Some questions come as plain prose and end the turn. Read the final assistant text. Append the question and the user's answer to `/tmp/ori-task.txt`, then restart from the full prompt file. |
-| `403 Key limit exceeded` or a 402 payment error in the stream | The user's OpenRouter key has no credit. Refer to the section below. |
+| The credential is missing | Stop. Tell the user to run `ori login`, or `! ori login` in Claude Code. The command opens a browser, so you cannot do it. |
+| A long pause on the first run | The first run creates `~/.ori/global` and downloads templates. It takes about 30 seconds and is not a stopped run. |
+| Ori does nothing and the prompt looks empty | The path in the start command does not match the file you wrote. |
+| Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
+| The eval file is outside `evals/` | Move the file and run `ori eval` on the new path. |
+| The run is longer than expected | Read the stream. If a question event is sitting there, kill the process now rather than waiting for the result line. |
+| Ori picked the target itself | The question event was missed or the run continued past it. Kill it, ask the user, append the answer, and restart from the full prompt file. |
+| No question arrives but the run looks stopped | Some questions come as plain prose and end the turn. Read the final assistant text and restart the same way. |
+| `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |
 
-### When the key has no credit
-
-A run that stops in seconds with `403 Key limit exceeded (total limit)` or a 402 payment error is not a defect in Ori or in the eval. The OpenRouter credential behind `ori login` is at its spend limit. Perform the following steps:
-
-1. Tell the user directly: the OpenRouter key has no credit, no eval was written, and this attempt spent nothing.
-2. Give the user the exact `Manage it using <url>` link from the error message. Ask if the user wants to increase the limit or add credits.
-3. Tell the user that the dashboard change is sufficient. The credential in `~/.ori/credentials.json` stays valid. A new `ori login` is not necessary.
-4. When the user confirms, start the same run command again. Continue from the same point. Do not stop the task.
+A run that dies within seconds on a key limit or payment error is not a defect in Ori or in the eval. Tell the user plainly that the key has no credit, no eval was written, and the attempt spent nothing. Give them the exact `Manage it using <url>` link from the error and ask whether to raise the limit or add credits. The dashboard change is enough, since the credential stays valid and a new `ori login` is not needed. When they confirm, start the same run again.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -97,6 +97,8 @@ One `{"kind":"event","event":...}` line per runtime event, then one final `{"kin
 
 Show the `message` first and the picker second, because the message carries context the labels do not, such as the markdown table of surface and current model. Keep Ori's options one for one, keep "Other" as free text, and translate the wording into simple language.
 
+What you append afterwards is the question's full message in plain language plus the answer: the selected option and any free text for a form, the selected option for a permission request.
+
 ## Appendix E: cost and timing table
 
 Include one row for every run, including each run you stopped at a question, since a restart repeats repo exploration. The total row sums `usage.costUsd` across every `turn.succeeded` and `turn.failed` event in every run, because each of those events reports one turn rather than the session. Build the table yourself if Ori's reply has no table, using each turn's `turn.started` timestamp, its duration to its terminal event, and that event's cost, plus the eval's model calls and judging from the report's Judging table or from `data.results`.
@@ -128,4 +130,4 @@ Follow it with one line, for example: this cost about $31.82 across two Ori runs
 | No question arrives but the run looks stopped | Some questions come as plain prose and end the turn. Read the final assistant text and restart the same way. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |
 
-A run that dies within seconds on a key limit or payment error is not a defect in Ori or in the eval. Tell the user plainly that the key has no credit, no eval was written, and the attempt spent nothing. Give them the exact `Manage it using <url>` link from the error and ask whether to raise the limit or add credits. The dashboard change is enough, since the credential stays valid and a new `ori login` is not needed. When they confirm, start the same run again.
+A run that dies within seconds on a key limit or payment error is not a defect in Ori or in the eval. Tell the user plainly that the key has no credit, no eval was written, and the attempt spent nothing. Give them the exact `Manage it using <url>` link from the error and ask whether to raise the limit or add credits. The dashboard change is enough, since the credential stays valid and a new `ori login` is not needed. When they confirm, start the same run again and continue the task from the same point, since the error is a recoverable pause rather than a terminal failure.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -9,32 +9,32 @@ Ori writes and grades the eval on a pinned harness and model, so the bench is id
 
 ## Steps
 
-Do these in order. Each one is a single action.
+Do these in order. One line, one action. Appendix letters point to the detail.
 
-1. Run `command -v ori`, and if it is missing run `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`.
-2. If the lookup still fails, run `~/.local/bin/ori --version`, and if that also fails, stop and report it.
-3. Confirm `~/.ori/credentials.json` exists, and if it does not, stop and tell the user to run `ori login`.
-4. Run `command -v bun`, and if it is missing, stop and tell the user to install Bun, which Ori uses to execute `*.eval.ts`.
-5. Read the eval surface by running `ori eval -h` and `ori eval skill`, falling back to `ori skills get create-eval` if the second errors, and continue to step 6 even if both error.
-6. If you installed the binary, tell the user it is at `~/.local/bin/ori`.
-7. Tell the user that a separate agent will pick a target, write an eval file under `evals/`, and score the models, describing the run from what you read in step 5 rather than from memory.
-8. Tell the user it takes roughly 10 to 30 minutes and spends real money that may exceed the credit on their key.
-9. Tell the user they will get a scored table, that Ori may ask questions, and that answering one restarts the run.
-10. Write `/tmp/ori-task.txt` from the prompt template below.
-11. Start one background run from the repo root with the start command below, and save the process ID.
-12. Read the current run's output file, `/tmp/ori-output-<n>.jsonl`, as it grows.
-13. Report each milestone as it appears, such as target picked, eval written, model 2 of 3 running.
-14. Kill the saved process ID the moment a question appears, meaning an `elicitation.requested` event, a `permission.requested` event, or a turn that ends on a prose question, and if the run instead finishes with no question, skip to step 19.
-15. Show the user the question's `payload.message` as plain text.
-16. Ask the user with your own question UI, one option per Ori option, with "Other" left as free text.
-17. Append the question and the user's answer to `/tmp/ori-task.txt`.
-18. Start a fresh run over the whole prompt file with the next output file number and a newly saved process ID, then return to step 12.
-19. Relay the full result table, the ship or no-ship decision, and the quoted failures.
-20. Relay Ori's cost and timing table in full.
-21. Add one row per run, including every run you stopped at a question, and a total row summing `usage.costUsd` across every `turn.succeeded` and `turn.failed` event in every run.
-22. Add one line separating the one-time authoring cost from the cheaper re-run cost.
+1. Find or install the `ori` binary (appendix A).
+2. If it is still missing, try `~/.local/bin/ori`, and stop if that fails too.
+3. Confirm `~/.ori/credentials.json` exists, and stop if it does not (appendix F).
+4. Confirm `bun` exists, and stop if it does not.
+5. Read the eval surface, continuing even if the commands error (appendix A).
+6. Tell the user where the binary landed, if you installed it.
+7. Tell the user what the run will do, from what you read in step 5.
+8. Tell the user it takes 10 to 30 minutes and spends real money.
+9. Tell the user they get a scored table and that a question can restart the run.
+10. Write the task prompt file (appendix B).
+11. Start one background run from the repo root and save the process ID (appendix C).
+12. Read the current run's output file as it grows (appendix D).
+13. Report each milestone as it appears.
+14. Kill the run the moment a question appears, or skip to step 19 if it finishes without one (appendix D).
+15. Show the user the question text as plain text.
+16. Ask the user with your own question UI, one option per Ori option.
+17. Append the question and the user's answer to the task prompt file.
+18. Restart over the whole prompt file with the next output file number, then return to step 12.
+19. Relay the result table, the ship or no-ship decision, and the quoted failures.
+20. Relay Ori's cost and timing table in full (appendix E).
+21. Add one row per run and a total row (appendix E).
+22. Add one line on the cheaper cost of a re-run.
 23. Tell the user to commit the `*.eval.ts` file.
-24. Offer to add `ori eval evals/<feature>/<name>.eval.ts` to CI.
+24. Offer to add `ori eval <file>` to CI.
 
 ## Rules
 
@@ -59,11 +59,15 @@ These hold for the whole run.
 - Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", "harness", "elicitation", "correlationId", "the result line", and "stdout".
 - Never copy CLI details into this skill or into text for the user. Re-read what step 5 printed for run options, reports, baselines, timeouts, and the eval-file API, because the CLI changes and copies go stale.
 
-## Reference
+## Appendix A: setup commands
 
-### Prompt template
+Install the binary with `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`. It lands in `~/.local/bin`, which is frequently absent from PATH in a non-login shell, so try `~/.local/bin/ori --version` before reporting a failure. Bun is required because Ori executes `*.eval.ts` with it.
 
-Fill in every angle-bracket field.
+Read the eval surface with `ori eval -h` and `ori eval skill`, falling back to `ori skills get create-eval` if the second errors. This is what Ori itself follows inside the run, so it tells you what the run will do and which questions it will ask. It never blocks the task: if both commands error, carry on.
+
+## Appendix B: task prompt template
+
+Write this to `/tmp/ori-task.txt`, filling in every angle-bracket field.
 
 ```text
 Use the create-eval skill.
@@ -75,9 +79,9 @@ Write the eval to evals/<feature>/<name>.eval.ts and run it with ori eval. Do
 not create or modify anything outside the top-level evals directory.
 ```
 
-### Start command
+## Appendix C: start command
 
-Raise the output file number on each restart.
+Raise the output file number on each restart, and save the new process ID each time.
 
 ```bash
 ori code --prompt-file /tmp/ori-task.txt --output jsonl > /tmp/ori-output-1.jsonl 2> /tmp/ori-error-1.log &
@@ -85,13 +89,17 @@ ori_pid=$!
 printf 'Ori process: %s\n' "$ori_pid"
 ```
 
-### Stream shape
+## Appendix D: stream shape
+
+The current run's output file is `/tmp/ori-output-<n>.jsonl`, where `<n>` is the number you gave the run you last started. Milestones worth reporting are things like target picked, eval written, and model 2 of 3 running. A question means an `elicitation.requested` event, a `permission.requested` event, or a turn that ends on a prose question, and you kill the saved process ID as soon as one appears rather than waiting for the result line.
 
 One `{"kind":"event","event":...}` line per runtime event, then one final `{"kind":"result","ok":...,"sessionId":"..."}` line. Ori's reply text is the sequence of `assistant.text.delta` payloads. An `elicitation.requested` payload carries a `message` and `fields[]`, each field with a `name`, a `type`, and often `options`. A `permission.requested` payload carries `options`.
 
-### Cost table
+Show the `message` first and the picker second, because the message carries context the labels do not, such as the markdown table of surface and current model. Keep Ori's options one for one, keep "Other" as free text, and translate the wording into simple language.
 
-Build this yourself if Ori's reply has no table, using each turn's `turn.started` timestamp, its duration to its terminal event, and that event's cost, plus the eval's model calls and judging from the report's Judging table or from `data.results`.
+## Appendix E: cost and timing table
+
+Include one row for every run, including each run you stopped at a question, since a restart repeats repo exploration. The total row sums `usage.costUsd` across every `turn.succeeded` and `turn.failed` event in every run, because each of those events reports one turn rather than the session. Build the table yourself if Ori's reply has no table, using each turn's `turn.started` timestamp, its duration to its terminal event, and that event's cost, plus the eval's model calls and judging from the report's Judging table or from `data.results`.
 
 | Step | Start | Duration | Cost |
 | -- | -- | -- | -- |
@@ -105,7 +113,7 @@ Build this yourself if Ori's reply has no table, using each turn's `turn.started
 
 Follow it with one line, for example: this cost about $31.82 across two Ori runs, and re-running the eval costs only about $0.51.
 
-### Troubleshooting
+## Appendix F: troubleshooting
 
 | Symptom | Do this |
 |---|---|

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -27,7 +27,7 @@ Do these in order. One line, one action. Appendix letters point to the detail.
 14. Kill the run the moment a question appears, or skip to step 19 if it finishes without one (appendix D).
 15. Show the user the question text as plain text.
 16. Ask the user with your own question UI, one option per Ori option.
-17. Append the question and the user's answer to the task prompt file.
+17. Append the question and the user's answer to the task prompt file (appendix D).
 18. Restart over the whole prompt file with the next output file number, then return to step 12.
 19. Relay the result table, the ship or no-ship decision, and the quoted failures.
 20. Relay Ori's cost and timing table in full (appendix E).


### PR DESCRIPTION
## Summary

The skill mixed three shapes of instruction: seven numbered steps, lettered sub-steps inside three of them, a per-section rules block under most steps, and a separate global rules section. An agent running it had to track nesting while working, and constraints were duplicated between the local blocks and the global one.

It is now 24 steps of one line each, a Rules section holding every constraint for the whole run, and six lettered appendices carrying the detail that steps point at. Rebased on main, so the eval-surface reading step from #118 is folded in as its own step.

- Sub-steps 1a to 1d and 5a to 5c became top-level steps, each keeping its own stop condition since the shared fail-stop preamble is gone. The surface read stays non-blocking.
- Every step is one line with no code blocks, tables, or embedded rationale. Commands, payload shapes, the cost table, and troubleshooting moved into appendices A to F, referenced inline from the step that needs them.
- Per-step rules blocks were merged into the single Rules list, deduplicated against the old hard rules.
- The no-credit recovery procedure is prose rather than a nested numbered list, since a numbered list inside troubleshooting reads like part of the main sequence.
- The question-handling steps carry the branch explicitly: step 14 either kills the run or skips ahead to the relay steps, so a clean run is never restarted.

No behavior guidance was dropped. Everything from the old per-step blocks and hard rules section is present, either as a rule or in an appendix, including the raw key rule, the ban on pasting the surface output, the message-before-picker instruction, the secret handling rule, the internal vocabulary ban, and the unmeasured-cost rule.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/5a13c5ab33034737b44f0587ff38c6d2
Requested by: @louisgv
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->