### PR TITLE
docs(spawn-ori-eval): warn that a run can exceed the key's credit

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -18,7 +18,7 @@ Do these in order. One line, one action. Appendix letters point to the detail.
 5. Read the eval surface, continuing even if the commands error (appendix A).
 6. Tell the user where the binary landed, if you installed it.
 7. Tell the user what the run will do, from what you read in step 5.
-8. Tell the user it takes 10 to 30 minutes and spends real money.
+8. Tell the user it takes 10 to 30 minutes and can spend more than the credit on their key.
 9. Tell the user they get a scored table and that a question can restart the run.
 10. Write the task prompt file (appendix B).
 11. Start one background run from the repo root and save the process ID (appendix C).


### PR DESCRIPTION
## Summary

Follow-up to #119. The cost disclosure step lost one clause during the one-line compression: the old wording warned that the run may spend more than the credit the user added when they authenticated, while the flattened step only said it spends real money. That warning is the reason the disclosure exists, since running out of credit mid-run is the failure the troubleshooting section exists to recover from.

The step now reads that it takes 10 to 30 minutes and can spend more than the credit on their key.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/5a13c5ab33034737b44f0587ff38c6d2
Requested by: @louisgv
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->