### PR TITLE
docs(spawn-ori-eval): use plain completed turns instead of a JSONL stream

### DIFF
--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -17,14 +17,14 @@ For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) s
 ## Prerequisites
 
 - `ori` on PATH — `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`
-- OpenRouter access — a credential stored by `ori login`
+- OpenRouter access resolved by `ori auth`; sign in with `ori login` if needed
 - [Bun](https://bun.sh), which Ori uses to execute `*.eval.ts`
 
 ## What it covers
 
 See [SKILL.md](SKILL.md) for the full reference, including:
 
-- Preflight for the `ori` binary, stored login credential, and Bun, including the `~/.local/bin` PATH gap
+- Preflight for the `ori` binary, `ori auth`, and Bun, including the `~/.local/bin` PATH gap
 - Reading the live eval help and the authoring guide before spawning, so the run is described from the current CLI rather than from memory
 - Telling the user in plain language what was installed, what is running, what it costs, and what they will get back
 - Running one plain-text headless Ori invocation at a time without overriding the pinned harness or model

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -17,18 +17,18 @@ For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) s
 ## Prerequisites
 
 - `ori` on PATH — `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`
-- Ori auth — `~/.ori/credentials.json` (via `ori login`)
+- OpenRouter access — `OPENROUTER_API_KEY` exported in the environment
 - [Bun](https://bun.sh), which Ori uses to execute `*.eval.ts`
 
 ## What it covers
 
 See [SKILL.md](SKILL.md) for the full reference, including:
 
-- Preflight for the `ori` binary, auth, and Bun, including the `~/.local/bin` PATH gap
+- Preflight for the `ori` binary, `OPENROUTER_API_KEY`, and Bun, including the `~/.local/bin` PATH gap
 - Reading the live eval help and the authoring guide before spawning, so the run is described from the current CLI rather than from memory
 - Telling the user in plain language what was installed, what is running, what it costs, and what they will get back
-- Backgrounding a single headless Ori invocation without overriding the pinned harness or model
-- Stopping Ori when it asks a question, showing it to the user, and restarting from the full prompt file with the answer appended
+- Running one plain-text headless Ori invocation at a time without overriding the pinned harness or model
+- Waiting for each turn to finish, showing a tagged question to the user, and restarting from the full prompt file with the answer appended
 - A fill-in-the-blanks task prompt that keeps the throwaway eval in a temporary workspace outside the user's repository
 - Anti-patterns: self-authored evals, subagent "evals", evals written into the user's repo, evals hidden in the repo's own test framework, answering Ori's questions on the user's behalf
 - Reporting the temporary workspace so the user can keep the eval if the numbers made them want it

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -17,14 +17,14 @@ For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) s
 ## Prerequisites
 
 - `ori` on PATH — `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`
-- OpenRouter access — `OPENROUTER_API_KEY` exported in the environment
+- OpenRouter access — a credential stored by `ori login`
 - [Bun](https://bun.sh), which Ori uses to execute `*.eval.ts`
 
 ## What it covers
 
 See [SKILL.md](SKILL.md) for the full reference, including:
 
-- Preflight for the `ori` binary, `OPENROUTER_API_KEY`, and Bun, including the `~/.local/bin` PATH gap
+- Preflight for the `ori` binary, stored login credential, and Bun, including the `~/.local/bin` PATH gap
 - Reading the live eval help and the authoring guide before spawning, so the run is described from the current CLI rather than from memory
 - Telling the user in plain language what was installed, what is running, what it costs, and what they will get back
 - Running one plain-text headless Ori invocation at a time without overriding the pinned harness or model

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -17,7 +17,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 4. Otherwise archive whatever is in the directory and write a fresh `steps.txt` covering step 5 onward (appendix A).
 5. Run the lookup or install for the `ori` binary yourself (appendix B).
 6. If it is still missing, run the `~/.local/bin/ori` fallback yourself, and stop if that fails too.
-7. Check `~/.ori/credentials.json` yourself, and stop if it does not exist because `ori login` opens a browser only the user can complete (appendix G).
+7. Check that `OPENROUTER_API_KEY` is present in the environment yourself, and stop with export instructions if it is missing (appendix B).
 8. Check for `bun` yourself, and stop if it is missing.
 9. Read the eval surface yourself, continuing even if the commands error (appendix B).
 10. Tell the user where the binary landed, if you installed it.
@@ -25,20 +25,19 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 12. Tell the user it takes 10 to 30 minutes and can spend more than the credit on their key.
 13. Tell the user they get a scored table and that a question can restart the run.
 14. Write the task prompt file (appendix C).
-15. Start one background run from the repo root and save the process ID (appendix D).
-16. Read the current run's output file as it grows (appendix E).
-17. Report each phase banner as a milestone.
-18. Kill the run the moment any question appears, whether it is a tagged elicitation, a permission request, or trailing prose, or skip to step 23 if it finishes without one (appendix E).
-19. Show the user the question text as plain text.
-20. Ask the user with your own question UI, one option per Ori option.
-21. Append the question and the user's answer to the task prompt file (appendix E).
-22. Restart over the whole prompt file with the next output file number, then return to step 16.
-23. Relay the result table, the ship or no-ship decision, and the quoted failures.
-24. Relay Ori's cost and timing table in full (appendix F).
-25. Add one row per run and a total row (appendix F).
-26. Add one line on the cheaper cost of a re-run.
-27. Tell the user where Ori left the temporary workspace and that it is throwaway.
-28. Say they can move the eval into their repo if the numbers made them want to keep it.
+15. Start one run from the repo root and capture its answer and error files (appendix D).
+16. Wait for the run to exit, then read the answer file (appendix E).
+17. If the turn ends on a tagged question, continue to step 18; otherwise skip to step 22 for the final report (appendix E).
+18. Show the user the question text as plain text.
+19. Ask the user with your own question UI, one option per Ori option.
+20. Append the question and the user's answer to the task prompt file (appendix E).
+21. Restart over the whole prompt file with the next attempt number, then return to step 16.
+22. Relay the result table, the ship or no-ship decision, and the quoted failures.
+23. Relay Ori's cost and timing table in full (appendix F).
+24. Add one row per attempt and a total row (appendix F).
+25. Add one line on the cheaper cost of a re-run.
+26. Tell the user where Ori left the temporary workspace and that it is throwaway.
+27. Say they can move the eval into their repo if the numbers made them want to keep it.
 
 ## Rules
 
@@ -47,24 +46,24 @@ These hold for the whole run.
 - Never write the eval yourself and never delegate it to your own subagent. Ori's `create-eval` skill runs automatically inside the run.
 - Never pass `--model` or `--harness`. They remove the pin, which is the only reason to use Ori.
 - Always pass `--prompt-file`. The `-p` flag works but never use it here, because a one-time string cannot carry state across a restart, and a bare positional prompt is rejected outright.
-- Run every command in steps 5 to 9 yourself. Installing the binary when it is missing is expected, not a permission request. The credential check is the only human handoff because `ori login` opens a browser only the user can complete.
+- Run every command in steps 5 to 9 yourself. Installing the binary when it is missing is expected. The credential check is the only setup handoff.
 - Update `steps.txt` as you go: mark a step current before you do it and done before you start the next, and reread the file to decide what comes next instead of trusting memory. A restart replays the prompt file from the top, so this is the only record of how far the last attempt got.
 - Run one Ori process at a time, never one per candidate model. `ori eval` is what compares models.
-- Treat the run directory's `task.txt` as the only task prompt state. Append every later message to it, resend the whole file on every restart, never use `--session`, and never split the history into separate answer files.
+- Treat the run directory's `task.txt` as the only task prompt state. Append every later message to it, resend the whole file on every restart, never use `--session`, and keep one answer file and one error log per attempt.
 - Never ask the user what to eval before the run. Ori's interview covers the surface, success criteria, real data, cost limit, and baseline model. Pass a vague or empty request through unchanged.
-- Never answer Ori's question or accept a permission request on the user's behalf. If you cannot reach the user, stop and wait. A guessed target produces an invalid eval that looks correct.
-- Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are the questions detected in step 18.
-- Never go silent. An unreported question and 25 minutes without a progress report both look like a stopped run.
-- Never invent a number. A turn with no reported cost is unmeasured, not zero, and you say so rather than estimating.
+- Never answer Ori's question on the user's behalf. If you cannot reach the user, stop and wait. A guessed target produces an invalid eval that looks correct.
+- Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are tagged questions at the end of a completed turn.
+- Each turn is silent from start to finish. Say that plainly before starting it. Do not report phase banners as milestones because they arrive only when the turn ends.
+- Never invent a number. Use Ori's closing table and the operator's measured wall clock. A missing cost or duration is unmeasured, not zero.
 - Never name a winner unless the production model is in the table. "No change" is a valid result.
 - Never give model ids or prices from memory. Check live prices on OpenRouter.
-- Never tell the user to export a raw `OPENROUTER_API_KEY`. The `ori login` command is the supported path.
+- The setup check must confirm `OPENROUTER_API_KEY` is present in the environment. The stored login credential covers `ori code` but not `ori eval`, so tell the user to export the key when it is missing. The key belongs to the user, and only they can supply it.
 - Never paste step 9's output to the user. You read it, they did not ask for it.
 - Never print a secret value from `credentials.json`, a `.env` file, or a config file. Name the key and its location only, such as `OPENAI_API_KEY at .env:4`.
 - Never write the eval into the user's repository. It is a throwaway measuring instrument, not something they asked to keep, and the decision to keep it is theirs to make after they see the numbers.
 - Never put the eval inside the repo's own test framework. `ori eval` finds `*.eval.ts` files only, so a pytest, vitest, or Go test file silently never runs.
 - Never present raw API calls as an Ori eval. If you measure another way, label it clearly.
-- Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", "harness", "elicitation", "correlationId", "the result line", and "stdout".
+- Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", and "harness".
 - Never copy CLI details into this skill or into text for the user. Re-read what step 9 printed for run options, reports, baselines, timeouts, and the eval-file API, because the CLI changes and copies go stale.
 
 ## Appendix A: run directory and step tracker
@@ -80,7 +79,7 @@ mkdir -p "$run_dir"
 
 The `shasum` fallback is there because `sha256sum` is GNU coreutils and absent on stock macOS, where the command would otherwise produce nothing and give every repository the same directory.
 
-Every file the run produces lives there and nowhere else: `steps.txt`, `task.txt`, and each attempt's `output-<n>.jsonl` and `error-<n>.log`. The directory is per repository, so two repos evaluated on one machine never read each other's prompt or progress.
+Every file the run produces lives there and nowhere else: `steps.txt`, `task.txt`, and each attempt's `answer-<n>.txt` and `error-<n>.log`. The directory is per repository, so two repos evaluated on one machine never read each other's prompt or answer.
 
 `steps.txt` carries the user's request on its first line and then one line for each step from 5 onward, each marked `todo`, `current`, or `done`. Steps 1 to 4 are not tracked, because they are what produce the file.
 
@@ -89,8 +88,8 @@ request: which model should we use for the support triage agent
 5 done look up the ori binary
 6 done fallback lookup not needed
 ...
-15 current start one background run
-16 todo read the output file as it grows
+15 current start one run
+16 todo wait for it to exit and read the answer file
 ```
 
 Adopt that file only when its first line matches the request you are working on and a step is still unfinished, which is the restart case. A different request in a repo you have evaluated before is a new run, so archive the old files and start clean, which also keeps stale logs out of the output numbering. Archive into a timestamped directory rather than a single `previous/`, so a third run does not move an archive into itself or overwrite the one before it.
@@ -110,15 +109,16 @@ Install the binary with `curl -fsSL https://openrouter.ai/labs/ori/install.sh | 
 
 Read the eval surface with `ori eval -h` and `ori eval skill`, falling back to `ori skills get create-eval` if the second errors. This is what Ori itself follows inside the run, so it tells you what the run will do and which questions it will ask. It never blocks the task: if both commands error, carry on.
 
+Check that `OPENROUTER_API_KEY` is present in the environment before starting. The stored credential from `ori login` covers `ori code`, but `ori eval` reads only the environment variable. If it is missing, tell the user to export it and stop.
+
 ## Appendix C: task prompt template
 
 Write this to `task.txt` in the run directory, filling in every angle-bracket field.
 
 ```text
 Use the create-eval skill. Follow its five phases in this order: workspace
-context, criteria and narrowing, bakeoff, routing, close. There are exactly
-three user stopping points, tagged `workspace-context`, `narrowing`, and
-`next-step`.
+context, criteria and narrowing, bakeoff, routing, close. The expected
+stopping points are tagged `workspace-context`, `narrowing`, and `next-step`.
 
 User request: <verbatim request>
 Repo context pointers: <paths>. Read these first.
@@ -130,58 +130,60 @@ the user's repository.
 
 ## Appendix D: start command
 
-Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the stream and error log the cost table is built from. Save the new process ID each time.
+Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the answer and error log used for the cost table. Run it in the foreground and time it yourself.
 
 ```bash
 run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
 run_dir="/tmp/spawn-ori-eval-$run_hash"
 n=1
-while [ -e "$run_dir/output-$n.jsonl" ]; do n=$((n + 1)); done
-ori code --prompt-file "$run_dir/task.txt" --output jsonl > "$run_dir/output-$n.jsonl" 2> "$run_dir/error-$n.log" &
-ori_pid=$!
-printf 'Ori attempt %s, process %s\n' "$n" "$ori_pid"
+while [ -e "$run_dir/answer-$n.txt" ]; do n=$((n + 1)); done
+start=$(date +%s)
+ori code --prompt-file "$run_dir/task.txt" > "$run_dir/answer-$n.txt" 2> "$run_dir/error-$n.log"
+status=$?
+duration=$(( $(date +%s) - start ))
+printf 'Ori attempt %s exited with status %s after %ss\n' "$n" "$status" "$duration"
 ```
 
-## Appendix E: stream shape
+## Appendix E: answer shape
 
-The current run's output file is `output-<n>.jsonl` in the run directory, where `<n>` is the number you gave the run you last started. Report each literal phase banner matching `Phase N/5: <phase name>` as a milestone. A question means an `elicitation.requested` event, a `permission.requested` event, or a turn that ends on a prose question, and you kill the saved process ID as soon as one appears rather than waiting for the result line.
+The current run's answer file is `answer-<n>.txt` in the run directory. The process writes the complete assistant answer when the turn settles, so wait for it to exit before reading it. There is no live progress source, no question detection during the turn, and nothing to kill.
 
-One `{"kind":"event","event":...}` line per runtime event, then one final `{"kind":"result","ok":...,"sessionId":"..."}` line. Ori's reply text is the sequence of `assistant.text.delta` payloads. An `elicitation.requested` payload carries a form with a top-level `message` whose first characters are exactly one of `[workspace-context]`, `[narrowing]`, or `[next-step]`, plus a `requestedSchema` with one projection-defined property whose choices are the options. Match the tag at the start of `message`, not a schema title or property name. A `permission.requested` payload is separate and carries `options`. Expect exactly three tagged elicitations across the run. If no phase banners appear, report progress from whatever the stream does show rather than going silent. If Ori asks a trailing prose question, stop and bring it to the user, but report it as a contract violation rather than treating it as a normal stopping point.
+A finished turn ends either on a tagged question or on the final report. A tagged question starts with exactly `[workspace-context]`, `[narrowing]`, or `[next-step]`. Show the full question and its options to the user. Ask with the operator's own question UI, one option per option Ori offered. Append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect.
 
-Show the `message` first and the picker second, because the message carries context the labels do not, such as the markdown table of surface and current model. Keep Ori's options one for one, keep "Other" as free text, and translate the wording into simple language.
+Show the question first and the picker second, because the question carries context the labels do not, such as the markdown table of surface and current model. Keep Ori's options one for one, keep "Other" as free text, and translate the wording into simple language.
 
-What you append afterwards is the question's full message in plain language plus the single answer string, including the typed text when the user chose Other, or the selected option for a permission request.
+What you append afterwards is the question's full text in plain language plus the single answer string, including the typed text when the user chose Other.
 
 ## Appendix F: cost and timing table
 
-Include one row for every run, including each run you stopped at a question, since a restart repeats repo exploration. The total row sums `usage.costUsd` across every `turn.succeeded` and `turn.failed` event in every run, because each of those events reports one turn rather than the session. Build the table yourself if Ori's reply has no table, using each turn's `turn.started` timestamp, its duration to its terminal event, and that event's cost, plus the eval's model calls and judging from the report's Judging table or from `data.results`.
+Include one row for every attempt, including each attempt that ended at a question, since a restart repeats repo exploration. Copy Ori's cost and timing table from the final answer. Add the operator's measured wall clock for each attempt. Build no stream-derived totals. If a value is absent, write "unmeasured", which is not zero.
 
 | Step | Start | Duration | Cost |
 | -- | -- | -- | -- |
 | Repo exploration | 20:26 | 2m 20s | $3.20 |
-| Run stopped at question 1 | 20:29 | 39s | $0.42 |
-| Restart and repeated exploration | 20:30 | 15m 10s | $27.69 |
+| Attempt stopped at question 1 | 20:29 | 39s | unmeasured |
+| Restart and repeated exploration | 20:30 | 15m 10s | unmeasured |
 | Eval model calls | 20:46 | 2m | $0.46 |
 | Judging | 20:48 | 1m | $0.05 |
 | … |  |  |  |
-| **Total** |  | **21m 09s** | **$31.82** |
+| **Measured floor** |  | **21m 09s** | **at least $3.71** |
 
-Follow it with one line, for example: this cost about $31.82 across two Ori runs, and re-running the eval costs only about $0.51.
+Follow it with one line, for example: the measured cost floor is $3.71. The two question-stopped attempts have unmeasured cost, so the complete total is unknown. A rerun costs only the amount shown in Ori's closing table.
 
 ## Appendix G: troubleshooting
 
 | Symptom | Do this |
 |---|---|
 | `ori: command not found` after a good installation | Run `~/.local/bin/ori`. The installer's PATH change does not apply to the current shell. |
-| The credential is missing | Stop. Tell the user to run `ori login`, or `! ori login` in Claude Code. The command opens a browser, so you cannot do it. |
+| The credential is missing | Stop. Tell the user to export `OPENROUTER_API_KEY`. The stored `ori login` credential covers `ori code` but not `ori eval`. |
 | A long pause on the first run | The first run creates `~/.ori/global` and downloads templates. It takes about 30 seconds and is not a stopped run. |
 | Ori does nothing and the prompt looks empty | The path in the start command does not match the file you wrote. |
 | Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
 | The eval file is inside the user's repository | Move it and its supporting files to a temporary workspace and run `ori eval` on the new path. |
-| The run is longer than expected | Read the stream. If a question event is sitting there, kill the process now rather than waiting for the result line. |
-| Ori picked the target itself | The question event was missed or the run continued past it. Kill it, ask the user, append the answer, and restart from the full prompt file. |
-| No question arrives but the run looks stopped | Some questions come as plain prose and end the turn. Read the final assistant text and restart the same way. |
+| The run is longer than expected | Wait for the process to exit. There is no live progress source or question detection during a turn. |
+| Ori picked the target itself | The question was not written as the last thing in the turn. Do not accept the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
+| The answer has no tagged question but the run looks stopped | Read the final answer. A completed turn ends on a tagged question or the final report. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |
 
 A run that dies within seconds on a key limit or payment error is not a defect in Ori or in the eval. Tell the user plainly that the key has no credit, no eval was written, and the attempt spent nothing. Give them the exact `Manage it using <url>` link from the error and ask whether to raise the limit or add credits. The dashboard change is enough, since the credential stays valid and a new `ori login` is not needed. When they confirm, start the same run again and continue the task from the same point, since the error is a recoverable pause rather than a terminal failure.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -17,7 +17,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 4. Otherwise archive whatever is in the directory and write a fresh `steps.txt` covering step 5 onward (appendix A).
 5. Run the lookup or install for the `ori` binary yourself (appendix B).
 6. If it is still missing, run the `~/.local/bin/ori` fallback yourself, and stop if that fails too.
-7. Check that the user has completed `ori login` yourself, and stop with login instructions if the stored credential is missing (appendix B).
+7. Run `ori auth` yourself and branch on its exit status: continue when access resolves, stop with login instructions when it does not, and tell the user to update Ori if the command is unknown (appendix B).
 8. Check for `bun` yourself, and stop if it is missing.
 9. Read the eval surface yourself, continuing even if the commands error (appendix B).
 10. Tell the user where the binary landed, if you installed it.
@@ -57,7 +57,7 @@ These hold for the whole run.
 - Never invent a number. Use Ori's closing table. An attempt stopped at a question has no reported cost, so name it unmeasured rather than zero.
 - Never name a winner unless the production model is in the table. "No change" is a valid result.
 - Never give model ids or prices from memory. Check live prices on OpenRouter.
-- The setup check must confirm that `ori login` has stored a credential. Tell the user to run `ori login` when it is missing.
+- The setup check must confirm that OpenRouter access resolves through `ori auth`. Tell the user to run `ori login` when it does not.
 - Never paste step 9's output to the user. You read it, they did not ask for it.
 - Never print a secret value from `credentials.json`, a `.env` file, or a config file. Name the key and its location only, such as `OPENAI_API_KEY at .env:4`.
 - Never write the eval into the user's repository. It is a throwaway measuring instrument, not something they asked to keep, and the decision to keep it is theirs to make after they see the numbers.
@@ -109,7 +109,7 @@ Install the binary with `curl -fsSL https://openrouter.ai/labs/ori/install.sh | 
 
 Read the eval surface with `ori eval -h` and `ori eval skill`, falling back to `ori skills get create-eval` if the second errors. This is what Ori itself follows inside the run, so it tells you what the run will do and which questions it will ask. It never blocks the task: if both commands error, carry on.
 
-Check that `ori login` has stored a credential before starting. If it is missing, tell the user to run `ori login` and stop. The current `ori eval` command still checks only `OPENROUTER_API_KEY` in the environment, so this supported login path requires the CLI to make that stored credential available to the eval process.
+Run `ori auth` before starting. It resolves the credential the CLI will use, including an inherited environment key, and exits zero when access is available. Do not print its output or any credential value. If it exits non-zero because no credential resolves, tell the user to run `ori login` and stop. If the binary reports that `auth` is an unknown command, tell the user to update Ori and stop.
 
 ## Appendix C: task prompt template
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -27,7 +27,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 14. Write the task prompt file (appendix C).
 15. Start one detached run from the repo root and capture its answer and error files (appendix D).
 16. Poll for the run to exit, then read the answer file (appendix E).
-17. If the turn ends on a question, continue to step 18; otherwise skip to step 22 for the final report (appendix E).
+17. If the completed answer contains a tagged question anywhere, or ends with an untagged question, continue to step 18; otherwise skip to step 22 for the final report (appendix E).
 18. Show the user the question text as plain text.
 19. Ask the user with your own question UI, one option per Ori option.
 20. Append the question and the user's answer to the task prompt file (appendix E).
@@ -138,20 +138,28 @@ run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; }
 run_dir="/tmp/spawn-ori-eval-$run_hash"
 n=1
 while [ -e "$run_dir/pid-$n.txt" ]; do n=$((n + 1)); done
+pid_file="$run_dir/pid-$n.txt"
+: > "$pid_file"
+ori_bin=$(command -v ori 2>/dev/null || true)
+if [ ! -x "$ori_bin" ] && [ -x "$HOME/.local/bin/ori" ]; then
+  ori_bin="$HOME/.local/bin/ori"
+fi
+[ -x "$ori_bin" ] || { printf 'Could not find the ori binary\n' >&2; exit 1; }
 start_epoch=$(date +%s)
 start_clock=$(date '+%H:%M:%S')
 status_file="$run_dir/status-$n.txt"
 nohup sh -c '
-  ori code --prompt-file "$1" > "$2" 2> "$3"
-  printf "%s\n" "$?" > "$4"
+  "$1" code --prompt-file "$2" > "$3" 2> "$4"
+  printf "%s\n" "$?" > "$5"
 ' sh \
+  "$ori_bin" \
   "$run_dir/task.txt" \
   "$run_dir/answer-$n.txt" \
   "$run_dir/error-$n.log" \
   "$status_file" \
   </dev/null >/dev/null 2>&1 &
 ori_pid=$!
-printf '%s\n' "$ori_pid" > "$run_dir/pid-$n.txt"
+printf '%s\n' "$ori_pid" > "$pid_file"
 printf '%s\n' "$start_epoch" > "$run_dir/start-$n.epoch"
 printf '%s\n' "$start_clock" > "$run_dir/start-$n.clock"
 printf 'Ori attempt %s started as process %s at %s\n' "$n" "$ori_pid" "$start_clock"
@@ -177,13 +185,17 @@ for pid_file in "$run_dir"/pid-*.txt; do
 done
 [ "$n" -gt 0 ] || { printf 'No started Ori attempt found\n' >&2; exit 1; }
 pid=$(cat "$run_dir/pid-$n.txt")
+case "$pid" in
+  ''|*[!0-9]*) printf 'Ori attempt %s did not record a process id\n' "$n" >&2; exit 1 ;;
+esac
 start_epoch=$(cat "$run_dir/start-$n.epoch")
 start_clock=$(cat "$run_dir/start-$n.clock")
 poll_start_epoch=$(date +%s)
 deadline=$((poll_start_epoch + 40 * 60))
 timed_out=0
 last_notice=$poll_start_epoch
-while kill -0 "$pid" 2>/dev/null; do
+status_file="$run_dir/status-$n.txt"
+while [ ! -f "$status_file" ] && kill -0 "$pid" 2>/dev/null; do
   now=$(date +%s)
   if [ "$now" -ge "$deadline" ]; then
     printf 'Ori attempt %s exceeded this 40-minute polling window; this is wall-clock time, not run progress\n' "$n" >&2

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -137,7 +137,7 @@ run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
 run_dir="/tmp/spawn-ori-eval-$run_hash"
 n=1
-while [ -e "$run_dir/answer-$n.txt" ]; do n=$((n + 1)); done
+while [ -e "$run_dir/pid-$n.txt" ]; do n=$((n + 1)); done
 start_epoch=$(date +%s)
 start_clock=$(date '+%H:%M:%S')
 status_file="$run_dir/status-$n.txt"
@@ -159,7 +159,7 @@ printf 'Ori attempt %s started as process %s at %s\n' "$n" "$ori_pid" "$start_cl
 
 ## Appendix E: answer shape
 
-The current run's answer file is `answer-<n>.txt` in the run directory. Read the saved process ID and poll it until it exits before reading the answer. Then read the saved exit status and calculate the duration from the saved start epoch. If the status file is missing, the process exited nonzero, or the answer file is empty, read the error log and report the failed attempt instead of treating it as a completed turn. There is no live progress source during the turn and nothing to kill.
+The current run's answer file is `answer-<n>.txt` in the run directory. Read the saved process ID and poll it until it exits before reading the answer. Give each polling shell a fresh 40-minute wait window anchored to when that poll starts. An expired window is a report to the user, not a verdict on the run, so resume polling from a later shell if needed. Calculate the total attempt duration from the saved start epoch. If the status file is missing, the process exited nonzero, or the answer file is empty, read the error log and report the failed attempt instead of treating it as a completed turn. There is no live progress source during the turn and nothing to kill.
 
 ```bash
 run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -179,13 +179,14 @@ done
 pid=$(cat "$run_dir/pid-$n.txt")
 start_epoch=$(cat "$run_dir/start-$n.epoch")
 start_clock=$(cat "$run_dir/start-$n.clock")
-deadline=$((start_epoch + 40 * 60))
+poll_start_epoch=$(date +%s)
+deadline=$((poll_start_epoch + 40 * 60))
 timed_out=0
-last_notice=$start_epoch
+last_notice=$poll_start_epoch
 while kill -0 "$pid" 2>/dev/null; do
   now=$(date +%s)
   if [ "$now" -ge "$deadline" ]; then
-    printf 'Ori attempt %s exceeded the 40-minute wait deadline; this is wall-clock time, not run progress\n' "$n" >&2
+    printf 'Ori attempt %s exceeded this 40-minute polling window; this is wall-clock time, not run progress\n' "$n" >&2
     timed_out=1
     break
   fi
@@ -199,7 +200,7 @@ duration=$(( $(date +%s) - start_epoch ))
 status=$(cat "$run_dir/status-$n.txt" 2>/dev/null || printf 'missing')
 printf 'Ori attempt %s started at %s and lasted %ss\n' "$n" "$start_clock" "$duration"
 if [ "$timed_out" -eq 1 ]; then
-  printf 'Stop waiting and tell the user the run exceeded the documented envelope. Do not read a partial answer or kill the process; resume polling it from a later shell if needed.\n' >&2
+  printf 'Report that this polling window expired, not that the run failed. Do not read a partial answer or kill the process; resume polling it from a later shell if needed.\n' >&2
   exit 1
 fi
 if [ "$status" = missing ] || [ "$status" != 0 ] || [ ! -s "$run_dir/answer-$n.txt" ]; then

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -27,7 +27,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 14. Write the task prompt file (appendix C).
 15. Start one run from the repo root and capture its answer and error files (appendix D).
 16. Wait for the run to exit, then read the answer file (appendix E).
-17. If the completed answer contains a tagged question anywhere, or ends with an untagged question, continue to step 18; otherwise skip to step 22 for the final report (appendix E).
+17. If the completed answer contains a tagged question anywhere, continue to step 18; if it ends with an untagged question, report the broken contract and stop; otherwise skip to step 22 for the final report (appendix E).
 18. Show the user the question text as plain text.
 19. Ask the user with your own question UI, one option per Ori option.
 20. Append the question and the user's answer to the task prompt file (appendix E).
@@ -117,8 +117,9 @@ Write this to `task.txt` in the run directory, filling in every angle-bracket fi
 
 ```text
 Use the create-eval skill. Follow its five phases in this order: workspace
-context, criteria and narrowing, bakeoff, routing, close. The expected
-stopping points are tagged `workspace-context`, `narrowing`, and `next-step`.
+context, criteria and narrowing, bakeoff, routing, close. There are exactly
+four user stopping points, tagged `workspace-context`, `narrowing`,
+`candidates`, and `next-step`.
 
 User request: <verbatim request>
 Repo context pointers: <paths>. Read these first.
@@ -149,7 +150,7 @@ If the operator's shell calls are cut off before a run ends, background the comm
 
 The current run's answer file is `answer-<n>.txt` in the run directory. The process writes the complete assistant answer when the turn settles, so read the answer file after it exits. Diagnostics go to the error log. There is no live progress source or question detection during the turn.
 
-A finished turn ends either on a question or on the final report. Find a tagged question anywhere in the completed answer, and treat any narration after it as noise rather than evidence that the turn continued past the question. An untagged question at the end of the answer is handled the same way. Show the full question and its options to the user, ask with the operator's own question UI, append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect. If Ori answered its own scoping question instead, discard that attempt rather than relaying it as a result, ask the user, append the answer, and restart.
+A finished turn ends either on a tagged question or on the final report. Find a tagged question anywhere in the completed answer, and treat any narration after it as noise rather than evidence that the turn continued past the question. An untagged question at the end of the answer is a contract violation: report it to the user, tell them to update Ori, and stop rather than relaying it or restarting. Show the full tagged question and its options to the user, ask with the operator's own question UI, append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect. If Ori answered its own scoping question instead, discard that attempt rather than relaying it as a result, ask the user, append the answer, and restart.
 
 Show the question first and the picker second, because the question carries context the labels do not, such as the markdown table of surface and current model. Keep Ori's options one for one, keep "Other" as free text, and translate the wording into simple language.
 
@@ -182,7 +183,7 @@ Follow it with one line, for example: the reported cost floor is $3.71. The two 
 | Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
 | The eval file is inside the user's repository | Move it and its supporting files to a temporary workspace and run `ori eval` on the new path. |
 | Ori picked the target itself | Discard the attempt rather than accepting the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
-| The answer has no tagged question but the run looks stopped | Read the final answer. A completed turn ending in an untagged question is handled like a tagged question. |
+| The answer has no tagged question but the run looks stopped | Read the final answer. A completed turn ending in an untagged question is a broken contract. Tell the user to update Ori and stop rather than restarting. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |
 
 A run that dies within seconds on a key limit or payment error is not a defect in Ori or in the eval. Tell the user plainly that the key has no credit, no eval was written, and the attempt spent nothing. Give them the exact `Manage it using <url>` link from the error and ask whether to raise the limit or add credits. The dashboard change is enough, since the credential stays valid and a new `ori login` is not needed. When they confirm, start the same run again and continue the task from the same point, since the error is a recoverable pause rather than a terminal failure.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -25,16 +25,16 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 12. Tell the user it takes 10 to 30 minutes and can spend more than the credit on their key.
 13. Tell the user they get a scored table and that a question can restart the run.
 14. Write the task prompt file (appendix C).
-15. Start one run from the repo root and capture its answer and error files (appendix D).
-16. Wait for the run to exit, then read the answer file (appendix E).
-17. If the turn ends on a tagged question, continue to step 18; otherwise skip to step 22 for the final report (appendix E).
+15. Start one detached run from the repo root and capture its answer and error files (appendix D).
+16. Poll for the run to exit, then read the answer file (appendix E).
+17. If the turn ends on a question, continue to step 18; otherwise skip to step 22 for the final report (appendix E).
 18. Show the user the question text as plain text.
 19. Ask the user with your own question UI, one option per Ori option.
 20. Append the question and the user's answer to the task prompt file (appendix E).
 21. Restart over the whole prompt file with the next attempt number, then return to step 16.
 22. Relay the result table, the ship or no-ship decision, and the quoted failures.
 23. Relay Ori's cost and timing table in full (appendix F).
-24. Add one row per attempt and a total row (appendix F).
+24. Add one row per attempt and report the measured cost floor (appendix F).
 25. Add one line on the cheaper cost of a re-run.
 26. Tell the user where Ori left the temporary workspace and that it is throwaway.
 27. Say they can move the eval into their repo if the numbers made them want to keep it.
@@ -130,7 +130,7 @@ the user's repository.
 
 ## Appendix D: start command
 
-Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the answer and error log used for the cost table. Run it in the foreground and time it yourself.
+Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the answer and error log used for the cost table. Start it detached, save its process ID, and time it yourself.
 
 ```bash
 run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -139,17 +139,16 @@ run_dir="/tmp/spawn-ori-eval-$run_hash"
 n=1
 while [ -e "$run_dir/answer-$n.txt" ]; do n=$((n + 1)); done
 start=$(date +%s)
-ori code --prompt-file "$run_dir/task.txt" > "$run_dir/answer-$n.txt" 2> "$run_dir/error-$n.log"
-status=$?
-duration=$(( $(date +%s) - start ))
-printf 'Ori attempt %s exited with status %s after %ss\n' "$n" "$status" "$duration"
+ori code --prompt-file "$run_dir/task.txt" > "$run_dir/answer-$n.txt" 2> "$run_dir/error-$n.log" &
+ori_pid=$!
+printf 'Ori attempt %s started as process %s at %ss\n' "$n" "$ori_pid" "$start"
 ```
 
 ## Appendix E: answer shape
 
-The current run's answer file is `answer-<n>.txt` in the run directory. The process writes the complete assistant answer when the turn settles, so wait for it to exit before reading it. There is no live progress source, no question detection during the turn, and nothing to kill.
+The current run's answer file is `answer-<n>.txt` in the run directory. The process writes the complete assistant answer when the turn settles, so poll the saved process ID until it exits before reading it. There is no live progress source, no question detection during the turn, and nothing to kill.
 
-A finished turn ends either on a tagged question or on the final report. A tagged question starts with exactly `[workspace-context]`, `[narrowing]`, or `[next-step]`. Show the full question and its options to the user. Ask with the operator's own question UI, one option per option Ori offered. Append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect.
+A finished turn ends either on a question or on the final report. A question may start with `[workspace-context]`, `[narrowing]`, or `[next-step]`, or it may be untagged prose at the end of the answer. Handle either form the same way: show the full question and its options to the user, ask with the operator's own question UI, append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect. If Ori answered its own scoping question instead, discard that attempt rather than relaying it as a result, ask the user, append the answer, and restart.
 
 Show the question first and the picker second, because the question carries context the labels do not, such as the markdown table of surface and current model. Keep Ori's options one for one, keep "Other" as free text, and translate the wording into simple language.
 
@@ -181,9 +180,9 @@ Follow it with one line, for example: the measured cost floor is $3.71. The two 
 | Ori does nothing and the prompt looks empty | The path in the start command does not match the file you wrote. |
 | Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
 | The eval file is inside the user's repository | Move it and its supporting files to a temporary workspace and run `ori eval` on the new path. |
-| The run is longer than expected | Wait for the process to exit. There is no live progress source or question detection during a turn. |
-| Ori picked the target itself | The question was not written as the last thing in the turn. Do not accept the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
-| The answer has no tagged question but the run looks stopped | Read the final answer. A completed turn ends on a tagged question or the final report. |
+| The run is longer than expected | Poll the saved process ID until it exits. There is no live progress source or question detection during a turn, and nothing to kill. |
+| Ori picked the target itself | Discard the attempt rather than accepting the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
+| The answer has no tagged question but the run looks stopped | Read the final answer. A completed turn ending in an untagged question is handled like a tagged question. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |
 
 A run that dies within seconds on a key limit or payment error is not a defect in Ori or in the eval. Tell the user plainly that the key has no credit, no eval was written, and the attempt spent nothing. Give them the exact `Manage it using <url>` link from the error and ask whether to raise the limit or add credits. The dashboard change is enough, since the credential stays valid and a new `ori login` is not needed. When they confirm, start the same run again and continue the task from the same point, since the error is a recoverable pause rather than a terminal failure.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -17,7 +17,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 4. Otherwise archive whatever is in the directory and write a fresh `steps.txt` covering step 5 onward (appendix A).
 5. Run the lookup or install for the `ori` binary yourself (appendix B).
 6. If it is still missing, run the `~/.local/bin/ori` fallback yourself, and stop if that fails too.
-7. Run `ori auth` yourself and branch on its exit status: continue when access resolves, stop with login instructions when it does not, and tell the user to update Ori if the command is unknown (appendix B).
+7. Run `ori auth` yourself, read its output, and branch on the exit status and message: continue when access resolves, stop with login instructions when no credential resolves, and tell the user to update Ori if the command is unknown (appendix B).
 8. Check for `bun` yourself, and stop if it is missing.
 9. Read the eval surface yourself, continuing even if the commands error (appendix B).
 10. Tell the user where the binary landed, if you installed it.
@@ -109,7 +109,7 @@ Install the binary with `curl -fsSL https://openrouter.ai/labs/ori/install.sh | 
 
 Read the eval surface with `ori eval -h` and `ori eval skill`, falling back to `ori skills get create-eval` if the second errors. This is what Ori itself follows inside the run, so it tells you what the run will do and which questions it will ask. It never blocks the task: if both commands error, carry on.
 
-Run `ori auth` before starting. It resolves the credential the CLI will use, including an inherited environment key, and exits zero when access is available. Do not print its output or any credential value. If it exits non-zero because no credential resolves, tell the user to run `ori login` and stop. If the binary reports that `auth` is an unknown command, tell the user to update Ori and stop, because that binary predates the change that makes the inner skill stop and ask instead of answering its own scoping question, producing an eval that looks correct but measures the wrong thing.
+Run `ori auth` before starting. It resolves the credential the CLI will use, including an inherited environment key, and exits zero when access is available. Read its output to distinguish an unknown command from a missing credential, but do not show that output to the user or repeat any credential value. If it exits non-zero because no credential resolves, tell the user to run `ori login` and stop. If the binary reports that `auth` is an unknown command, tell the user to update Ori and stop, because that binary predates the change that makes the inner skill stop and ask instead of answering its own scoping question, producing an eval that looks correct but measures the wrong thing.
 
 ## Appendix C: task prompt template
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -124,6 +124,9 @@ possible question tags in this order: `surface`, `workspace-files`,
 `workspace-data`, `criteria-priority`, `evaluation-constraint`, `candidates`,
 and `next-step`. The first two are mutually exclusive conditional questions,
 so each run asks five or six questions.
+Ask exactly one question per turn and end the turn after asking it. Give each
+question three concrete options plus a free-text `Other` option. Never combine
+questions in one turn.
 
 User request: <verbatim request>
 Repo context pointers: <paths>. Read these first.
@@ -167,15 +170,14 @@ Include one row for every attempt, including each attempt that ended at a questi
 
 | Step | Start | Duration | Cost |
 | -- | -- | -- | -- |
-| Repo exploration | 20:26 | 2m 20s | $3.20 |
 | Attempt stopped at question 1 | 20:29 | 39s | unmeasured |
-| Restart and repeated exploration | 20:30 | 15m 10s | unmeasured |
+| Restart and repeated exploration | 20:30 | 15m 10s | $3.20 |
 | Eval model calls | 20:46 | 2m | $0.46 |
 | Judging | 20:48 | 1m | $0.05 |
 | … |  |  |  |
 | **Reported floor** |  | **from Ori's table** | **at least $3.71** |
 
-Follow it with one line, for example: the reported cost floor is $3.71. The two question-stopped attempts have unmeasured cost, so the complete total is unknown. A rerun costs only the amount shown in Ori's closing table.
+Follow it with one line, for example: the reported cost floor is $3.71. The question-stopped attempt has unmeasured cost, so the complete total is unknown. A rerun costs only the amount shown in Ori's closing table.
 
 ## Appendix G: troubleshooting
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -162,6 +162,20 @@ printf 'Ori attempt %s started as process %s at %s\n' "$n" "$ori_pid" "$start_cl
 The current run's answer file is `answer-<n>.txt` in the run directory. Read the saved process ID and poll it until it exits before reading the answer. Then read the saved exit status and calculate the duration from the saved start epoch. If the status file is missing, the process exited nonzero, or the answer file is empty, read the error log and report the failed attempt instead of treating it as a completed turn. There is no live progress source during the turn and nothing to kill.
 
 ```bash
+run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
+run_dir="/tmp/spawn-ori-eval-$run_hash"
+n=0
+for pid_file in "$run_dir"/pid-*.txt; do
+  [ -e "$pid_file" ] || continue
+  attempt=${pid_file##*/pid-}
+  attempt=${attempt%.txt}
+  case "$attempt" in
+    ''|*[!0-9]*) continue ;;
+  esac
+  [ "$attempt" -gt "$n" ] && n=$attempt
+done
+[ "$n" -gt 0 ] || { printf 'No started Ori attempt found\n' >&2; exit 1; }
 pid=$(cat "$run_dir/pid-$n.txt")
 while kill -0 "$pid" 2>/dev/null; do sleep 5; done
 start_epoch=$(cat "$run_dir/start-$n.epoch")

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -17,7 +17,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 4. Otherwise archive whatever is in the directory and write a fresh `steps.txt` covering step 5 onward (appendix A).
 5. Run the lookup or install for the `ori` binary yourself (appendix B).
 6. If it is still missing, run the `~/.local/bin/ori` fallback yourself, and stop if that fails too.
-7. Check that `OPENROUTER_API_KEY` is present in the environment yourself, and stop with export instructions if it is missing (appendix B).
+7. Check that the user has completed `ori login` yourself, and stop with login instructions if the stored credential is missing (appendix B).
 8. Check for `bun` yourself, and stop if it is missing.
 9. Read the eval surface yourself, continuing even if the commands error (appendix B).
 10. Tell the user where the binary landed, if you installed it.
@@ -25,8 +25,8 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 12. Tell the user it takes 10 to 30 minutes and can spend more than the credit on their key.
 13. Tell the user they get a scored table and that a question can restart the run.
 14. Write the task prompt file (appendix C).
-15. Start one detached run from the repo root and capture its answer and error files (appendix D).
-16. Poll for the run to exit, then read the answer file (appendix E).
+15. Start one run from the repo root and capture its answer and error files (appendix D).
+16. Wait for the run to exit, then read the answer file (appendix E).
 17. If the completed answer contains a tagged question anywhere, or ends with an untagged question, continue to step 18; otherwise skip to step 22 for the final report (appendix E).
 18. Show the user the question text as plain text.
 19. Ask the user with your own question UI, one option per Ori option.
@@ -34,7 +34,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 21. Restart over the whole prompt file with the next attempt number, then return to step 16.
 22. Relay the result table, the ship or no-ship decision, and the quoted failures.
 23. Relay Ori's cost and timing table in full (appendix F).
-24. Add one row per attempt and report the measured cost floor (appendix F).
+24. Add Ori's reported cost and timing rows for each attempt, naming question-stopped attempts unmeasured and reporting a floor (appendix F).
 25. Add one line on the cheaper cost of a re-run.
 26. Tell the user where Ori left the temporary workspace and that it is throwaway.
 27. Say they can move the eval into their repo if the numbers made them want to keep it.
@@ -54,16 +54,16 @@ These hold for the whole run.
 - Never answer Ori's question on the user's behalf. If you cannot reach the user, stop and wait. A guessed target produces an invalid eval that looks correct.
 - Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are tagged questions at the end of a completed turn.
 - Each turn is silent from start to finish. Say that plainly before starting it. Do not report phase banners as milestones because they arrive only when the turn ends.
-- Never invent a number. Use Ori's closing table and the operator's measured wall clock. A missing cost or duration is unmeasured, not zero.
+- Never invent a number. Use Ori's closing table. An attempt stopped at a question has no reported cost, so name it unmeasured rather than zero.
 - Never name a winner unless the production model is in the table. "No change" is a valid result.
 - Never give model ids or prices from memory. Check live prices on OpenRouter.
-- The setup check must confirm `OPENROUTER_API_KEY` is present in the environment. The stored login credential covers `ori code` but not `ori eval`, so tell the user to export the key when it is missing. The key belongs to the user, and only they can supply it.
+- The setup check must confirm that `ori login` has stored a credential. Tell the user to run `ori login` when it is missing.
 - Never paste step 9's output to the user. You read it, they did not ask for it.
 - Never print a secret value from `credentials.json`, a `.env` file, or a config file. Name the key and its location only, such as `OPENAI_API_KEY at .env:4`.
 - Never write the eval into the user's repository. It is a throwaway measuring instrument, not something they asked to keep, and the decision to keep it is theirs to make after they see the numbers.
 - Never put the eval inside the repo's own test framework. `ori eval` finds `*.eval.ts` files only, so a pytest, vitest, or Go test file silently never runs.
 - Never present raw API calls as an Ori eval. If you measure another way, label it clearly.
-- Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", "harness", and "stdout".
+- Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", and "harness".
 - Never copy CLI details into this skill or into text for the user. Re-read what step 9 printed for run options, reports, baselines, timeouts, and the eval-file API, because the CLI changes and copies go stale.
 
 ## Appendix A: run directory and step tracker
@@ -109,7 +109,7 @@ Install the binary with `curl -fsSL https://openrouter.ai/labs/ori/install.sh | 
 
 Read the eval surface with `ori eval -h` and `ori eval skill`, falling back to `ori skills get create-eval` if the second errors. This is what Ori itself follows inside the run, so it tells you what the run will do and which questions it will ask. It never blocks the task: if both commands error, carry on.
 
-Check that `OPENROUTER_API_KEY` is present in the environment before starting. The stored credential from `ori login` covers `ori code`, but `ori eval` reads only the environment variable. If it is missing, tell the user to export it and stop.
+Check that `ori login` has stored a credential before starting. If it is missing, tell the user to run `ori login` and stop. The current `ori eval` command still checks only `OPENROUTER_API_KEY` in the environment, so this supported login path requires the CLI to make that stored credential available to the eval process.
 
 ## Appendix C: task prompt template
 
@@ -130,98 +130,24 @@ the user's repository.
 
 ## Appendix D: start command
 
-Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the answer and error log used for the cost table. Start it detached with stdin from `/dev/null`, save its process ID and start time in the run directory, and time it yourself.
+Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the answer and error log used for the cost table. Run it in the foreground.
 
 ```bash
 run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
 run_dir="/tmp/spawn-ori-eval-$run_hash"
 n=1
-while [ -e "$run_dir/pid-$n.txt" ]; do n=$((n + 1)); done
-pid_file="$run_dir/pid-$n.txt"
-: > "$pid_file"
-ori_bin=$(command -v ori 2>/dev/null || true)
-if [ ! -x "$ori_bin" ] && [ -x "$HOME/.local/bin/ori" ]; then
-  ori_bin="$HOME/.local/bin/ori"
-fi
-[ -x "$ori_bin" ] || { printf 'Could not find the ori binary\n' >&2; exit 1; }
-start_epoch=$(date +%s)
-start_clock=$(date '+%H:%M:%S')
-status_file="$run_dir/status-$n.txt"
-nohup sh -c '
-  "$1" code --prompt-file "$2" > "$3" 2> "$4"
-  printf "%s\n" "$?" > "$5"
-' sh \
-  "$ori_bin" \
-  "$run_dir/task.txt" \
-  "$run_dir/answer-$n.txt" \
-  "$run_dir/error-$n.log" \
-  "$status_file" \
-  </dev/null >/dev/null 2>&1 &
-ori_pid=$!
-printf '%s\n' "$ori_pid" > "$pid_file"
-printf '%s\n' "$start_epoch" > "$run_dir/start-$n.epoch"
-printf '%s\n' "$start_clock" > "$run_dir/start-$n.clock"
-printf 'Ori attempt %s started as process %s at %s\n' "$n" "$ori_pid" "$start_clock"
+while [ -e "$run_dir/answer-$n.txt" ]; do n=$((n + 1)); done
+ori code --prompt-file "$run_dir/task.txt" \
+  > "$run_dir/answer-$n.txt" \
+  2> "$run_dir/error-$n.log"
 ```
+
+If the operator's shell calls are cut off before a run ends, background the command and poll it using the operator's own process-management tools.
 
 ## Appendix E: answer shape
 
-The current run's answer file is `answer-<n>.txt` in the run directory. Read the saved process ID and poll it until it exits before reading the answer. Give each polling shell a fresh 40-minute wait window anchored to when that poll starts. An expired window is a report to the user, not a verdict on the run, so resume polling from a later shell if needed. Calculate the total attempt duration from the saved start epoch. If the status file is missing, the process exited nonzero, or the answer file is empty, read the error log and report the failed attempt instead of treating it as a completed turn. There is no live progress source during the turn and nothing to kill.
-
-```bash
-run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
-run_dir="/tmp/spawn-ori-eval-$run_hash"
-n=0
-for pid_file in "$run_dir"/pid-*.txt; do
-  [ -e "$pid_file" ] || continue
-  attempt=${pid_file##*/pid-}
-  attempt=${attempt%.txt}
-  case "$attempt" in
-    ''|*[!0-9]*) continue ;;
-  esac
-  [ "$attempt" -gt "$n" ] && n=$attempt
-done
-[ "$n" -gt 0 ] || { printf 'No started Ori attempt found\n' >&2; exit 1; }
-pid=$(cat "$run_dir/pid-$n.txt")
-case "$pid" in
-  ''|*[!0-9]*) printf 'Ori attempt %s did not record a process id\n' "$n" >&2; exit 1 ;;
-esac
-start_epoch=$(cat "$run_dir/start-$n.epoch")
-start_clock=$(cat "$run_dir/start-$n.clock")
-poll_start_epoch=$(date +%s)
-deadline=$((poll_start_epoch + 40 * 60))
-timed_out=0
-last_notice=$poll_start_epoch
-status_file="$run_dir/status-$n.txt"
-while [ ! -f "$status_file" ] && kill -0 "$pid" 2>/dev/null; do
-  now=$(date +%s)
-  if [ "$now" -ge "$deadline" ]; then
-    printf 'Ori attempt %s exceeded this 40-minute polling window; this is wall-clock time, not run progress\n' "$n" >&2
-    timed_out=1
-    break
-  fi
-  if [ "$((now - last_notice))" -ge 60 ]; then
-    printf 'Ori attempt %s has been running for %ss; this is wall-clock time, not run progress\n' "$n" "$((now - start_epoch))"
-    last_notice=$now
-  fi
-  sleep 5
-done
-duration=$(( $(date +%s) - start_epoch ))
-status=$(cat "$run_dir/status-$n.txt" 2>/dev/null || printf 'missing')
-printf 'Ori attempt %s started at %s and lasted %ss\n' "$n" "$start_clock" "$duration"
-if [ "$timed_out" -eq 1 ]; then
-  printf 'Report that this polling window expired, not that the run failed. Do not read a partial answer or kill the process; resume polling it from a later shell if needed.\n' >&2
-  exit 1
-fi
-if [ "$status" = missing ] || [ "$status" != 0 ] || [ ! -s "$run_dir/answer-$n.txt" ]; then
-  printf 'Ori attempt %s failed. Error log: %s\n' "$n" "$run_dir/error-$n.log" >&2
-  cat "$run_dir/error-$n.log"
-  exit 1
-fi
-cat "$run_dir/answer-$n.txt"
-```
+The current run's answer file is `answer-<n>.txt` in the run directory. The process writes the complete assistant answer when the turn settles, so read the answer file after it exits. Diagnostics go to the error log. There is no live progress source or question detection during the turn.
 
 A finished turn ends either on a question or on the final report. Find a tagged question anywhere in the completed answer, and treat any narration after it as noise rather than evidence that the turn continued past the question. An untagged question at the end of the answer is handled the same way. Show the full question and its options to the user, ask with the operator's own question UI, append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect. If Ori answered its own scoping question instead, discard that attempt rather than relaying it as a result, ask the user, append the answer, and restart.
 
@@ -231,7 +157,7 @@ What you append afterwards is the question's full text in plain language plus th
 
 ## Appendix F: cost and timing table
 
-Include one row for every attempt, including each attempt that ended at a question, since a restart repeats repo exploration. Copy Ori's cost and timing table from the final answer. Add the operator's measured wall clock for each attempt. Build no stream-derived totals. If a value is absent, write "unmeasured", which is not zero.
+Include one row for every attempt, including each attempt that ended at a question, since a restart repeats repo exploration. Copy Ori's cost and timing table from the final answer. Build no stream-derived totals. An attempt that ended at a question has no reported cost, so name it "unmeasured", which is not zero. Report a floor rather than adding unmeasured attempts into a total.
 
 | Step | Start | Duration | Cost |
 | -- | -- | -- | -- |
@@ -241,21 +167,20 @@ Include one row for every attempt, including each attempt that ended at a questi
 | Eval model calls | 20:46 | 2m | $0.46 |
 | Judging | 20:48 | 1m | $0.05 |
 | … |  |  |  |
-| **Measured floor** |  | **21m 09s** | **at least $3.71** |
+| **Reported floor** |  | **from Ori's table** | **at least $3.71** |
 
-Follow it with one line, for example: the measured cost floor is $3.71. The two question-stopped attempts have unmeasured cost, so the complete total is unknown. A rerun costs only the amount shown in Ori's closing table.
+Follow it with one line, for example: the reported cost floor is $3.71. The two question-stopped attempts have unmeasured cost, so the complete total is unknown. A rerun costs only the amount shown in Ori's closing table.
 
 ## Appendix G: troubleshooting
 
 | Symptom | Do this |
 |---|---|
 | `ori: command not found` after a good installation | Run `~/.local/bin/ori`. The installer's PATH change does not apply to the current shell. |
-| The credential is missing | Stop. Tell the user to export `OPENROUTER_API_KEY`. The stored `ori login` credential covers `ori code` but not `ori eval`. |
+| The credential is missing | Stop. Tell the user to run `ori login`. |
 | A long pause on the first run | The first run creates `~/.ori/global` and downloads templates. It takes about 30 seconds and is not a stopped run. |
 | Ori does nothing and the prompt looks empty | The path in the start command does not match the file you wrote. |
 | Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
 | The eval file is inside the user's repository | Move it and its supporting files to a temporary workspace and run `ori eval` on the new path. |
-| The run is longer than expected | Poll the saved process ID until it exits. There is no live progress source or question detection during a turn, and nothing to kill. |
 | Ori picked the target itself | Discard the attempt rather than accepting the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
 | The answer has no tagged question but the run looks stopped | Read the final answer. A completed turn ending in an untagged question is handled like a tagged question. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -177,12 +177,37 @@ for pid_file in "$run_dir"/pid-*.txt; do
 done
 [ "$n" -gt 0 ] || { printf 'No started Ori attempt found\n' >&2; exit 1; }
 pid=$(cat "$run_dir/pid-$n.txt")
-while kill -0 "$pid" 2>/dev/null; do sleep 5; done
 start_epoch=$(cat "$run_dir/start-$n.epoch")
-duration=$(( $(date +%s) - start_epoch ))
 start_clock=$(cat "$run_dir/start-$n.clock")
+deadline=$((start_epoch + 40 * 60))
+timed_out=0
+last_notice=$start_epoch
+while kill -0 "$pid" 2>/dev/null; do
+  now=$(date +%s)
+  if [ "$now" -ge "$deadline" ]; then
+    printf 'Ori attempt %s exceeded the 40-minute wait deadline; this is wall-clock time, not run progress\n' "$n" >&2
+    timed_out=1
+    break
+  fi
+  if [ "$((now - last_notice))" -ge 60 ]; then
+    printf 'Ori attempt %s has been running for %ss; this is wall-clock time, not run progress\n' "$n" "$((now - start_epoch))"
+    last_notice=$now
+  fi
+  sleep 5
+done
+duration=$(( $(date +%s) - start_epoch ))
 status=$(cat "$run_dir/status-$n.txt" 2>/dev/null || printf 'missing')
 printf 'Ori attempt %s started at %s and lasted %ss\n' "$n" "$start_clock" "$duration"
+if [ "$timed_out" -eq 1 ]; then
+  printf 'Stop waiting and tell the user the run exceeded the documented envelope. Do not read a partial answer or kill the process; resume polling it from a later shell if needed.\n' >&2
+  exit 1
+fi
+if [ "$status" = missing ] || [ "$status" != 0 ] || [ ! -s "$run_dir/answer-$n.txt" ]; then
+  printf 'Ori attempt %s failed. Error log: %s\n' "$n" "$run_dir/error-$n.log" >&2
+  cat "$run_dir/error-$n.log"
+  exit 1
+fi
+cat "$run_dir/answer-$n.txt"
 ```
 
 A finished turn ends either on a question or on the final report. Find a tagged question anywhere in the completed answer, and treat any narration after it as noise rather than evidence that the turn continued past the question. An untagged question at the end of the answer is handled the same way. Show the full question and its options to the user, ask with the operator's own question UI, append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect. If Ori answered its own scoping question instead, discard that attempt rather than relaying it as a result, ask the user, append the answer, and restart.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -63,7 +63,7 @@ These hold for the whole run.
 - Never write the eval into the user's repository. It is a throwaway measuring instrument, not something they asked to keep, and the decision to keep it is theirs to make after they see the numbers.
 - Never put the eval inside the repo's own test framework. `ori eval` finds `*.eval.ts` files only, so a pytest, vitest, or Go test file silently never runs.
 - Never present raw API calls as an Ori eval. If you measure another way, label it clearly.
-- Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", and "harness".
+- Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", "harness", and "stdout".
 - Never copy CLI details into this skill or into text for the user. Re-read what step 9 printed for run options, reports, baselines, timeouts, and the eval-file API, because the CLI changes and copies go stale.
 
 ## Appendix A: run directory and step tracker
@@ -130,7 +130,7 @@ the user's repository.
 
 ## Appendix D: start command
 
-Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the answer and error log used for the cost table. Start it detached, save its process ID, and time it yourself.
+Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the answer and error log used for the cost table. Start it detached with stdin from `/dev/null`, save its process ID and start time in the run directory, and time it yourself.
 
 ```bash
 run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -138,17 +138,40 @@ run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; }
 run_dir="/tmp/spawn-ori-eval-$run_hash"
 n=1
 while [ -e "$run_dir/answer-$n.txt" ]; do n=$((n + 1)); done
-start=$(date +%s)
-ori code --prompt-file "$run_dir/task.txt" > "$run_dir/answer-$n.txt" 2> "$run_dir/error-$n.log" &
+start_epoch=$(date +%s)
+start_clock=$(date '+%H:%M:%S')
+status_file="$run_dir/status-$n.txt"
+nohup sh -c '
+  ori code --prompt-file "$1" > "$2" 2> "$3"
+  printf "%s\n" "$?" > "$4"
+' sh \
+  "$run_dir/task.txt" \
+  "$run_dir/answer-$n.txt" \
+  "$run_dir/error-$n.log" \
+  "$status_file" \
+  </dev/null >/dev/null 2>&1 &
 ori_pid=$!
-printf 'Ori attempt %s started as process %s at %ss\n' "$n" "$ori_pid" "$start"
+printf '%s\n' "$ori_pid" > "$run_dir/pid-$n.txt"
+printf '%s\n' "$start_epoch" > "$run_dir/start-$n.epoch"
+printf '%s\n' "$start_clock" > "$run_dir/start-$n.clock"
+printf 'Ori attempt %s started as process %s at %s\n' "$n" "$ori_pid" "$start_clock"
 ```
 
 ## Appendix E: answer shape
 
-The current run's answer file is `answer-<n>.txt` in the run directory. The process writes the complete assistant answer when the turn settles, so poll the saved process ID until it exits before reading it. There is no live progress source, no question detection during the turn, and nothing to kill.
+The current run's answer file is `answer-<n>.txt` in the run directory. Read the saved process ID and poll it until it exits before reading the answer. Then read the saved exit status and calculate the duration from the saved start epoch. If the status file is missing, the process exited nonzero, or the answer file is empty, read the error log and report the failed attempt instead of treating it as a completed turn. There is no live progress source during the turn and nothing to kill.
 
-A finished turn ends either on a question or on the final report. A question may start with `[workspace-context]`, `[narrowing]`, or `[next-step]`, or it may be untagged prose at the end of the answer. Handle either form the same way: show the full question and its options to the user, ask with the operator's own question UI, append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect. If Ori answered its own scoping question instead, discard that attempt rather than relaying it as a result, ask the user, append the answer, and restart.
+```bash
+pid=$(cat "$run_dir/pid-$n.txt")
+while kill -0 "$pid" 2>/dev/null; do sleep 5; done
+start_epoch=$(cat "$run_dir/start-$n.epoch")
+duration=$(( $(date +%s) - start_epoch ))
+start_clock=$(cat "$run_dir/start-$n.clock")
+status=$(cat "$run_dir/status-$n.txt" 2>/dev/null || printf 'missing')
+printf 'Ori attempt %s started at %s and lasted %ss\n' "$n" "$start_clock" "$duration"
+```
+
+A finished turn ends either on a question or on the final report. Find a tagged question anywhere in the completed answer, and treat any narration after it as noise rather than evidence that the turn continued past the question. An untagged question at the end of the answer is handled the same way. Show the full question and its options to the user, ask with the operator's own question UI, append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. Do not treat an extra tagged question as a defect. If Ori answered its own scoping question instead, discard that attempt rather than relaying it as a result, ask the user, append the answer, and restart.
 
 Show the question first and the picker second, because the question carries context the labels do not, such as the markdown table of surface and current model. Keep Ori's options one for one, keep "Other" as free text, and translate the wording into simple language.
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -142,6 +142,7 @@ while [ -e "$run_dir/answer-$n.txt" ]; do n=$((n + 1)); done
 ori code --prompt-file "$run_dir/task.txt" \
   > "$run_dir/answer-$n.txt" \
   2> "$run_dir/error-$n.log"
+printf 'attempt %s answer: %s\n' "$n" "$run_dir/answer-$n.txt"
 ```
 
 If the operator's shell calls are cut off before a run ends, background the command and poll it using the operator's own process-management tools.


### PR DESCRIPTION
## Summary

`spawn-ori-eval` drove Ori through the structured event stream. It passed `--output jsonl`, read `output-<n>.jsonl` as it grew, matched `elicitation.requested` and `permission.requested` payloads to detect a question, killed the process the moment one appeared, and summed `usage.costUsd` across turn events to build its cost table. This switches it to plain completed turns.

```diff
-ori code --prompt-file task.txt --output jsonl > output-$n.jsonl 2> error-$n.log &
-ori_pid=$!   # then: tail the stream, match a question event, kill $ori_pid
+ori code --prompt-file task.txt > answer-$n.txt 2> error-$n.log
+# read answer-$n.txt after it exits
```

Two consequences are written into the skill rather than papered over.

A turn is silent from start to finish, because plain output lands in a single write when the turn settles. The skill says that plainly up front instead of promising phase banners as milestones, and it does not substitute an invented progress source.

Cost now comes from Ori's own closing table. An attempt that stopped at a question reports no cost anywhere, so those rows are named `unmeasured` and the total is presented as a floor rather than a sum, since summing over missing values would understate the real spend while looking authoritative.

Question handling no longer depends on a question arriving as a distinct event. A tagged question is matched anywhere in the completed answer, with trailing narration treated as noise rather than as evidence the turn continued past it, while an untagged question at the end is now read as a broken contract, reported with an update as the recovery, rather than relayed as a normal pause, since the inner skill tags every stopping point on current main. If Ori answered its own scoping question, the attempt is discarded rather than relayed, because a guessed target yields an eval that looks correct and measures the wrong thing.

The credential preflight asks `ori auth` instead of reasoning about where a credential file lives, so the check now resolves exactly what the CLI itself will use, an inherited environment key included. An unknown-command failure is read as a stale binary and stops the run, because a binary without that command also predates the create-eval change this skill depends on, so it would answer its own scoping question and produce an eval that measures the wrong thing. `ori eval` on main already resolves through the shared login gate, so the login path the preflight names is truthful end to end.

This also merges the four-tag stopping-point contract that landed on main in #125, keeping its tags and its untagged-question handling while dropping the stream mechanics it described.

Depends on two ori changes: OpenRouterIncubator/ori#1659, which makes `create-eval` end its turn on the tagged question instead of asking through a tool call that a headless run settles on the user's behalf, and #1669, which adds the `ori auth` command the preflight calls. Both need to be in a release before this merges, since the skill installs the published binary.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/abfe0b6dd4e845bcb7a893da25c9b217
Requested by: @louisgv
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->