### PR TITLE
docs(spawn-ori-eval): leave the run directory to the user, drop the shell recipes

### DIFF
--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -28,7 +28,7 @@ See [SKILL.md](SKILL.md) for the full reference, including:
 - Reading the live eval help and the authoring guide before spawning, so the run is described from the current CLI rather than from memory
 - Telling the user in plain language what was installed, what is running, what it costs, and what they will get back
 - Running one plain-text headless Ori invocation at a time without overriding the pinned harness or model
-- Asking the user whether to resume a stopped run or start over, instead of silently continuing whatever was left in the run directory
+- Reporting anything left in the run directory and letting the user decide whether to resume it or archive it, instead of continuing or clearing it unasked
 - Waiting for each turn to finish, showing one question with three options and free-text `Other`, and restarting from the full prompt file with the answer appended
 - A fill-in-the-blanks task prompt that keeps the throwaway eval in a temporary workspace outside the user's repository
 - Anti-patterns: self-authored evals, subagent "evals", evals written into the user's repo, evals hidden in the repo's own test framework, answering Ori's questions on the user's behalf

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -28,7 +28,7 @@ See [SKILL.md](SKILL.md) for the full reference, including:
 - Reading the live eval help and the authoring guide before spawning, so the run is described from the current CLI rather than from memory
 - Telling the user in plain language what was installed, what is running, what it costs, and what they will get back
 - Running one plain-text headless Ori invocation at a time without overriding the pinned harness or model
-- Reporting anything left in the run directory and letting the user decide whether to resume it or archive it, instead of continuing or clearing it unasked
+- Reporting anything left in the run directory and letting the user decide whether to resume it, archive it, or stop and read it first, instead of continuing or clearing it unasked
 - Waiting for each turn to finish, showing one question with three options and free-text `Other`, and restarting from the full prompt file with the answer appended
 - A fill-in-the-blanks task prompt that keeps the throwaway eval in a temporary workspace outside the user's repository
 - Anti-patterns: self-authored evals, subagent "evals", evals written into the user's repo, evals hidden in the repo's own test framework, answering Ori's questions on the user's behalf

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -28,6 +28,7 @@ See [SKILL.md](SKILL.md) for the full reference, including:
 - Reading the live eval help and the authoring guide before spawning, so the run is described from the current CLI rather than from memory
 - Telling the user in plain language what was installed, what is running, what it costs, and what they will get back
 - Running one plain-text headless Ori invocation at a time without overriding the pinned harness or model
+- Asking the user whether to resume a stopped run or start over, instead of silently continuing whatever was left in the run directory
 - Waiting for each turn to finish, showing one question with three options and free-text `Other`, and restarting from the full prompt file with the answer appended
 - A fill-in-the-blanks task prompt that keeps the throwaway eval in a temporary workspace outside the user's repository
 - Anti-patterns: self-authored evals, subagent "evals", evals written into the user's repo, evals hidden in the repo's own test framework, answering Ori's questions on the user's behalf

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -14,7 +14,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 1. Create the run directory and derive its path from the repo root (appendix A).
 2. Tell the user where the run directory is.
 3. Read whatever is already in the directory without changing it, and tell the user what is there and how old it is (appendix A).
-4. Ask the user what to do with it, then either reuse the existing `steps.txt` and jump to the first step after 4 that is not done, or archive the files and write a fresh `steps.txt` covering step 5 onward. Write the fresh tracker without asking only when the directory is empty (appendix A).
+4. Ask the user what to do with it, then reuse the existing `steps.txt` and jump to the first step after 4 that is not done, or archive the files and write a fresh `steps.txt` covering step 5 onward, or stop and leave everything untouched. Write the fresh tracker without asking only when the directory holds no run files of its own (appendix A).
 5. Run the lookup or install for the `ori` binary yourself (appendix B).
 6. If it is still missing, run the `~/.local/bin/ori` fallback yourself, and stop if that fails too.
 7. Run `ori auth` yourself, read its output, and branch on the exit status and message: continue when access resolves, stop with login instructions when no credential resolves, and tell the user to update Ori and stop if the command is unknown (appendix B).
@@ -47,7 +47,7 @@ These hold for the whole run.
 - Never pass `--model` or `--harness`. They remove the pin, which is the only reason to use Ori.
 - Always pass `--prompt-file`. The `-p` flag works but never use it here, because a one-time string cannot carry state across a restart, and a bare positional prompt is rejected outright.
 - Run every command in steps 5 to 9 yourself. Installing the binary when it is missing is expected. The credential check is the only setup handoff.
-- Never resume and never clear a previous run on your own judgement. The skill is loaded and run inside one session, so anything already in the directory came from a different one, and it is the only record of work the user paid for. Both paths out of step 4 need their answer first.
+- Never resume and never clear a previous run on your own judgement. The skill is loaded and run inside one session, so anything already in the directory came from a different one, and it is the only record of work the user paid for. Every path out of step 4 needs their answer first.
 - Update `steps.txt` as you go: mark a step current before you do it and done before you start the next, and reread the file to decide what comes next instead of trusting memory. A restart replays the prompt file from the top, so this is the only record of how far the last attempt got.
 - Run one Ori process at a time, never one per candidate model. `ori eval` is what compares models.
 - Treat the run directory's `task.txt` as the only task prompt state. Append every later message to it, resend the whole file on every restart, never use `--session`, and keep one answer file and one error log per attempt.
@@ -95,13 +95,13 @@ request: which model should we use for the support triage agent
 16 todo wait for it to exit and read the answer file
 ```
 
-An empty directory is the only case that needs no question, because there is nothing to decide about. Everything else goes to the user, whatever it holds. A tracker started for a different request, or one whose every step is done, is a reason to tell the user what they are looking at rather than a licence to clear it, because the answer files are the run they paid for and they may want to read them before anything moves.
+A directory with no run files of its own needs no question, because there is nothing to decide about. That covers a directory that is empty and one that holds only an earlier archive, since archiving leaves `previous/` behind for good. Everything else goes to the user, whatever it holds. A tracker started for a different request, or one whose every step is done, is a reason to tell the user what they are looking at rather than a licence to clear it, because the answer files are the run they paid for and they may want to read them before anything moves.
 
 So read the directory and report it. Give the user what they need to decide without opening it themselves: the request the old tracker was started for, the step it stopped at in plain language, how many attempts ran, and how long ago the last one wrote anything. Then ask with the operator's own question UI and wait.
 
-Offer resuming only when the old tracker's first line matches the request you are working on and a step is unfinished. Resuming anything else would resend another request's prompt file to Ori. When resuming is not on the table, the choice is between starting a new run, which archives the old files, and stopping so the user can read them first.
+Offer resuming only when the old tracker's first line matches the request you are working on and a step is unfinished. Resuming anything else would resend another request's prompt file to Ori. Starting a new run and stopping are always available, so the question has three answers at most and two at least.
 
-Resuming reuses what is there as it stands: mark up the same `steps.txt`, append to the same `task.txt`, and keep every earlier attempt in the cost table, because the user already paid for that work. Starting a new run archives the tracker, the prompt file, and every answer and error log, which drops the answers the user already gave Ori and pays for the repo exploration again. Say which of the two you are recommending and why, and let them decide.
+Resuming reuses what is there as it stands: mark up the same `steps.txt`, append to the same `task.txt`, and keep every earlier attempt in the cost table, because the user already paid for that work. Starting a new run archives the tracker, the prompt file, and every answer and error log, which drops the answers the user already gave Ori and pays for the repo exploration again. Stopping changes nothing and ends the task there, which is what the user wants when they would rather read the old files before anything moves. Say which one you are recommending and why, and let them decide.
 
 Archive into a timestamped directory rather than a single `previous/`, so a third run does not move an archive into itself or overwrite the one before it.
 
@@ -200,7 +200,7 @@ Follow it with one line, for example: the run cost $4.13 in total, and a rerun c
 
 | Symptom | Do this |
 |---|---|
-| The run directory is not empty | Report what is in it and ask the user. Never continue it and never clear it on your own. |
+| The run directory holds run files already | Report what is in it and ask the user. Never continue it and never clear it on your own. |
 | `ori: command not found` after a good installation | Run `~/.local/bin/ori`. The installer's PATH change does not apply to the current shell. |
 | The credential is missing | Stop. Tell the user to run `ori login`. |
 | A long pause on the first run | The first run creates `~/.ori/global` and downloads templates. It takes about 30 seconds and is not a stopped run. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -13,8 +13,8 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 
 1. Create the run directory and derive its path from the repo root (appendix A).
 2. Tell the user where the run directory is.
-3. Look for a resumable run and, when there is one, tell the user what it stopped at and how old it is (appendix A).
-4. Ask the user whether to resume it or start over, then jump to the first unfinished step after 4 if they resume, or archive the directory and write a fresh `steps.txt` covering step 5 onward if they start over or there is nothing to resume (appendix A).
+3. Read whatever is already in the directory without changing it, and tell the user what is there and how old it is (appendix A).
+4. Ask the user what to do with it, then either reuse the existing `steps.txt` and jump to the first step after 4 that is not done, or archive the files and write a fresh `steps.txt` covering step 5 onward. Write the fresh tracker without asking only when the directory is empty (appendix A).
 5. Run the lookup or install for the `ori` binary yourself (appendix B).
 6. If it is still missing, run the `~/.local/bin/ori` fallback yourself, and stop if that fails too.
 7. Run `ori auth` yourself, read its output, and branch on the exit status and message: continue when access resolves, stop with login instructions when no credential resolves, and tell the user to update Ori and stop if the command is unknown (appendix B).
@@ -47,13 +47,13 @@ These hold for the whole run.
 - Never pass `--model` or `--harness`. They remove the pin, which is the only reason to use Ori.
 - Always pass `--prompt-file`. The `-p` flag works but never use it here, because a one-time string cannot carry state across a restart, and a bare positional prompt is rejected outright.
 - Run every command in steps 5 to 9 yourself. Installing the binary when it is missing is expected. The credential check is the only setup handoff.
-- Never resume a previous run on your own judgement. A leftover directory is evidence that something stopped, not permission to continue it, and the earlier attempts already spent the user's credit. Resuming happens only after the user picks it in step 4.
+- Never resume and never clear a previous run on your own judgement. The skill is loaded and run inside one session, so anything already in the directory came from a different one, and it is the only record of work the user paid for. Both paths out of step 4 need their answer first.
 - Update `steps.txt` as you go: mark a step current before you do it and done before you start the next, and reread the file to decide what comes next instead of trusting memory. A restart replays the prompt file from the top, so this is the only record of how far the last attempt got.
 - Run one Ori process at a time, never one per candidate model. `ori eval` is what compares models.
 - Treat the run directory's `task.txt` as the only task prompt state. Append every later message to it, resend the whole file on every restart, never use `--session`, and keep one answer file and one error log per attempt.
 - Never ask the user what to eval before the run. Ori's interview covers the surface, success criteria, real data, cost limit, and baseline model. Pass a vague or empty request through unchanged.
 - Never answer Ori's question on the user's behalf. If you cannot reach the user, stop and wait. A guessed target produces an invalid eval that looks correct.
-- Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are the resume choice in step 4 and the questions handled by step 17.
+- Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are the run directory choice in step 4 and the questions handled by step 17.
 - Each turn is silent from start to finish. Say that plainly before starting it. Do not report phase banners as milestones because they arrive only when the turn ends.
 - Never invent a number. Every attempt reports its own duration and cost on the summary line that ends its answer file, and the eval's own model calls come from Ori's closing table. Name a figure unmeasured only when the attempt wrote no summary line at all.
 - Never name a winner unless the production model is in the table. "No change" is a valid result.
@@ -95,20 +95,13 @@ request: which model should we use for the support triage agent
 16 todo wait for it to exit and read the answer file
 ```
 
-A file is resumable only when its first line matches the request you are working on and a step is still unfinished. A different request in a repo you have evaluated before is not resumable, and neither is a file whose every step is done, so there is no question to ask in either case: archive the old files and start clean, which also keeps stale logs out of the output numbering.
+An empty directory is the only case that needs no question, because there is nothing to decide about. Everything else goes to the user, whatever it holds. A tracker started for a different request, or one whose every step is done, is a reason to tell the user what they are looking at rather than a licence to clear it, because the answer files are the run they paid for and they may want to read them before anything moves.
 
-When the file is resumable, ask the user before touching it. Give them what they need to decide without reading the directory themselves: the request on the first line, the step it stopped at in plain language, how many attempts already ran, and how long ago the last one wrote anything. Ask with the operator's own question UI, offering resuming and starting over as the two options, and say which files starting over archives. Resuming keeps every earlier attempt's cost in the final table, because the user already paid for that work. Starting over drops the whole prompt state, including the answers they already gave, and pays for the repo exploration again. Wait for the answer rather than picking the cheaper path yourself, because only the user knows whether the stopped attempt is still what they want.
+So read the directory and report it. Give the user what they need to decide without opening it themselves: the request the old tracker was started for, the step it stopped at in plain language, how many attempts ran, and how long ago the last one wrote anything. Then ask with the operator's own question UI and wait.
 
-The state you need for that question is in the tracker and the answer files.
+Offer resuming only when the old tracker's first line matches the request you are working on and a step is unfinished. Resuming anything else would resend another request's prompt file to Ori. When resuming is not on the table, the choice is between starting a new run, which archives the old files, and stopping so the user can read them first.
 
-```bash
-run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
-run_dir="/tmp/spawn-ori-eval-$run_hash"
-head -1 "$run_dir/steps.txt"
-grep -E ' (current|todo) ' "$run_dir/steps.txt" | head -1
-ls -lt "$run_dir"/answer-*.txt 2>/dev/null
-```
+Resuming reuses what is there as it stands: mark up the same `steps.txt`, append to the same `task.txt`, and keep every earlier attempt in the cost table, because the user already paid for that work. Starting a new run archives the tracker, the prompt file, and every answer and error log, which drops the answers the user already gave Ori and pays for the repo exploration again. Say which of the two you are recommending and why, and let them decide.
 
 Archive into a timestamped directory rather than a single `previous/`, so a third run does not move an archive into itself or overwrite the one before it.
 
@@ -207,7 +200,7 @@ Follow it with one line, for example: the run cost $4.13 in total, and a rerun c
 
 | Symptom | Do this |
 |---|---|
-| The run directory already holds a stopped run for this same request | Ask the user whether to resume it or start over. Never continue it on your own. |
+| The run directory is not empty | Report what is in it and ask the user. Never continue it and never clear it on your own. |
 | `ori: command not found` after a good installation | Run `~/.local/bin/ori`. The installer's PATH change does not apply to the current shell. |
 | The credential is missing | Stop. Tell the user to run `ori login`. |
 | A long pause on the first run | The first run creates `~/.ori/global` and downloads templates. It takes about 30 seconds and is not a stopped run. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -13,8 +13,8 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 
 1. Create the run directory and derive its path from the repo root (appendix A).
 2. Tell the user where the run directory is.
-3. Adopt `steps.txt` when it exists for this same request with work outstanding, and jump to the first step after 4 that is not done (appendix A).
-4. Otherwise archive whatever is in the directory and write a fresh `steps.txt` covering step 5 onward (appendix A).
+3. Look for a resumable run and, when there is one, tell the user what it stopped at and how old it is (appendix A).
+4. Ask the user whether to resume it or start over, then jump to the first unfinished step after 4 if they resume, or archive the directory and write a fresh `steps.txt` covering step 5 onward if they start over or there is nothing to resume (appendix A).
 5. Run the lookup or install for the `ori` binary yourself (appendix B).
 6. If it is still missing, run the `~/.local/bin/ori` fallback yourself, and stop if that fails too.
 7. Run `ori auth` yourself, read its output, and branch on the exit status and message: continue when access resolves, stop with login instructions when no credential resolves, and tell the user to update Ori and stop if the command is unknown (appendix B).
@@ -47,12 +47,13 @@ These hold for the whole run.
 - Never pass `--model` or `--harness`. They remove the pin, which is the only reason to use Ori.
 - Always pass `--prompt-file`. The `-p` flag works but never use it here, because a one-time string cannot carry state across a restart, and a bare positional prompt is rejected outright.
 - Run every command in steps 5 to 9 yourself. Installing the binary when it is missing is expected. The credential check is the only setup handoff.
+- Never resume a previous run on your own judgement. A leftover directory is evidence that something stopped, not permission to continue it, and the earlier attempts already spent the user's credit. Resuming happens only after the user picks it in step 4.
 - Update `steps.txt` as you go: mark a step current before you do it and done before you start the next, and reread the file to decide what comes next instead of trusting memory. A restart replays the prompt file from the top, so this is the only record of how far the last attempt got.
 - Run one Ori process at a time, never one per candidate model. `ori eval` is what compares models.
 - Treat the run directory's `task.txt` as the only task prompt state. Append every later message to it, resend the whole file on every restart, never use `--session`, and keep one answer file and one error log per attempt.
 - Never ask the user what to eval before the run. Ori's interview covers the surface, success criteria, real data, cost limit, and baseline model. Pass a vague or empty request through unchanged.
 - Never answer Ori's question on the user's behalf. If you cannot reach the user, stop and wait. A guessed target produces an invalid eval that looks correct.
-- Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are the questions handled by step 17.
+- Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are the resume choice in step 4 and the questions handled by step 17.
 - Each turn is silent from start to finish. Say that plainly before starting it. Do not report phase banners as milestones because they arrive only when the turn ends.
 - Never invent a number. Every attempt reports its own duration and cost on the summary line that ends its answer file, and the eval's own model calls come from Ori's closing table. Name a figure unmeasured only when the attempt wrote no summary line at all.
 - Never name a winner unless the production model is in the table. "No change" is a valid result.
@@ -94,7 +95,22 @@ request: which model should we use for the support triage agent
 16 todo wait for it to exit and read the answer file
 ```
 
-Adopt that file only when its first line matches the request you are working on and a step is still unfinished, which is the restart case. A different request in a repo you have evaluated before is a new run, so archive the old files and start clean, which also keeps stale logs out of the output numbering. Archive into a timestamped directory rather than a single `previous/`, so a third run does not move an archive into itself or overwrite the one before it.
+A file is resumable only when its first line matches the request you are working on and a step is still unfinished. A different request in a repo you have evaluated before is not resumable, and neither is a file whose every step is done, so there is no question to ask in either case: archive the old files and start clean, which also keeps stale logs out of the output numbering.
+
+When the file is resumable, ask the user before touching it. Give them what they need to decide without reading the directory themselves: the request on the first line, the step it stopped at in plain language, how many attempts already ran, and how long ago the last one wrote anything. Ask with the operator's own question UI, offering resuming and starting over as the two options, and say which files starting over archives. Resuming keeps every earlier attempt's cost in the final table, because the user already paid for that work. Starting over drops the whole prompt state, including the answers they already gave, and pays for the repo exploration again. Wait for the answer rather than picking the cheaper path yourself, because only the user knows whether the stopped attempt is still what they want.
+
+The state you need for that question is in the tracker and the answer files.
+
+```bash
+run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
+run_dir="/tmp/spawn-ori-eval-$run_hash"
+head -1 "$run_dir/steps.txt"
+grep -E ' (current|todo) ' "$run_dir/steps.txt" | head -1
+ls -lt "$run_dir"/answer-*.txt 2>/dev/null
+```
+
+Archive into a timestamped directory rather than a single `previous/`, so a third run does not move an archive into itself or overwrite the one before it.
 
 ```bash
 run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -191,6 +207,7 @@ Follow it with one line, for example: the run cost $4.13 in total, and a rerun c
 
 | Symptom | Do this |
 |---|---|
+| The run directory already holds a stopped run for this same request | Ask the user whether to resume it or start over. Never continue it on your own. |
 | `ori: command not found` after a good installation | Run `~/.local/bin/ori`. The installer's PATH change does not apply to the current shell. |
 | The credential is missing | Stop. Tell the user to run `ori login`. |
 | A long pause on the first run | The first run creates `~/.ori/global` and downloads templates. It takes about 30 seconds and is not a stopped run. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -71,16 +71,9 @@ These hold for the whole run.
 
 ## Appendix A: run directory and step tracker
 
-Derive the directory from the repo root, falling back to the working directory when there is no repo, so a restart from a subdirectory finds the same one. Re-derive it in every shell that needs it rather than relying on the variable surviving, because shell state usually does not persist between commands.
+What you need is one scratch directory outside the user's repository whose name is fixed by the repository being evaluated. Two properties matter. The same repository must always resolve to the same directory, including when the run is started from a subdirectory, so derive the name from the absolute path of the repository root and fall back to the working directory when there is no repository. Two different repositories must never resolve to the same directory, so whatever names it must vary with that path and must behave the same on Linux and macOS, where a tool present on only one of them would silently collapse every repository into one directory. Work the name out again in each shell that needs it rather than trusting a variable to survive, because shell state usually does not persist between commands.
 
-```bash
-run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
-run_dir="/tmp/spawn-ori-eval-$run_hash"
-mkdir -p "$run_dir"
-```
-
-The `shasum` fallback is there because `sha256sum` is GNU coreutils and absent on stock macOS, where the command would otherwise produce nothing and give every repository the same directory.
+Name it `spawn-ori-eval-<short hash of the repository root path>` in the system temporary directory. Keeping to that convention is what lets a later run of this skill find the same directory and see the earlier run at all.
 
 Every file the run produces lives there and nowhere else: `steps.txt`, `task.txt`, and each attempt's `answer-<n>.txt` and `error-<n>.log`. The directory is per repository, so two repos evaluated on one machine never read each other's prompt or answer.
 
@@ -103,16 +96,7 @@ Offer resuming only when the old tracker's first line matches the request you ar
 
 Resuming reuses what is there as it stands: mark up the same `steps.txt`, append to the same `task.txt`, and keep every earlier attempt in the cost table, because the user already paid for that work. Starting a new run archives the tracker, the prompt file, and every answer and error log, which drops the answers the user already gave Ori and pays for the repo exploration again. Stopping changes nothing and ends the task there, which is what the user wants when they would rather read the old files before anything moves. Say which one you are recommending and why, and let them decide.
 
-Archive into a timestamped directory rather than a single `previous/`, so a third run does not move an archive into itself or overwrite the one before it.
-
-```bash
-run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
-run_dir="/tmp/spawn-ori-eval-$run_hash"
-archive="$run_dir/previous/$(date +%Y%m%d-%H%M%S)"
-mkdir -p "$archive"
-find "$run_dir" -maxdepth 1 -type f -exec mv {} "$archive"/ \;
-```
+Archiving means the old run's files end up under `previous/` inside the run directory, in their own subdirectory named after the time they were moved, and nothing is deleted. Two things go wrong without the timestamp: a later archive overwrites an earlier one, and the archive directory gets moved inside itself. So move the run's own files and leave `previous/` where it is.
 
 ## Appendix B: setup commands
 
@@ -145,23 +129,13 @@ user's repository. Run it with ori eval. Do not create or modify anything in
 the user's repository.
 ```
 
-## Appendix D: start command
+## Appendix D: starting a run
 
-Take the first unused attempt number rather than a fixed one, so a restart does not overwrite the answer and error log used for the cost table. Run it in the foreground.
+What you want at the end of this step is one `ori code` process, started from the repository root with the whole prompt file passed to it, whose assistant text and whose diagnostics have landed in two separate files in the run directory under the same attempt number.
 
-```bash
-run_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-run_hash=$(printf '%s' "$run_root" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-12)
-run_dir="/tmp/spawn-ori-eval-$run_hash"
-n=1
-while [ -e "$run_dir/answer-$n.txt" ]; do n=$((n + 1)); done
-ori code --prompt-file "$run_dir/task.txt" \
-  > "$run_dir/answer-$n.txt" \
-  2> "$run_dir/error-$n.log"
-printf 'attempt %s answer: %s\n' "$n" "$run_dir/answer-$n.txt"
-```
+The attempt number is the first one not already used, never a fixed one, because the cost table is read back out of every attempt's files and an overwritten answer takes an attempt's cost with it. Keeping the two streams apart matters for the same reason: only the answer stream carries the assistant text and the summary line the cost table needs, and diagnostics mixed into it would corrupt both. Note which attempt number this run is using, since every later step refers to that attempt's files.
 
-If the operator's shell calls are cut off before a run ends, background the command and poll it using the operator's own process-management tools.
+Run it in the foreground. If the operator's shell calls are cut off before a run ends, background it instead and poll it with the operator's own process-management tools.
 
 ## Appendix E: answer shape
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -47,7 +47,7 @@ These hold for the whole run.
 - Never pass `--model` or `--harness`. They remove the pin, which is the only reason to use Ori.
 - Always pass `--prompt-file`. The `-p` flag works but never use it here, because a one-time string cannot carry state across a restart, and a bare positional prompt is rejected outright.
 - Run every command in steps 5 to 9 yourself. Installing the binary when it is missing is expected. The credential check is the only setup handoff.
-- Never resume and never clear a previous run on your own judgement. The skill is loaded and run inside one session, so anything already in the directory came from a different one, and it is the only record of work the user paid for. Every path out of step 4 needs their answer first.
+- Never resume and never clear a previous run on your own judgement. The skill is loaded and run inside one session, so anything already in the directory came from a different one, and it is the only record of work the user paid for. Every path out of step 4 needs their answer first, apart from the fresh start on a directory that holds no run files of its own.
 - Update `steps.txt` as you go: mark a step current before you do it and done before you start the next, and reread the file to decide what comes next instead of trusting memory. A restart replays the prompt file from the top, so this is the only record of how far the last attempt got.
 - Run one Ori process at a time, never one per candidate model. `ori eval` is what compares models.
 - Treat the run directory's `task.txt` as the only task prompt state. Append every later message to it, resend the whole file on every restart, never use `--session`, and keep one answer file and one error log per attempt.


### PR DESCRIPTION
## Summary

Two changes to the same part of the skill.

The skill used to decide by itself what to do with a run directory it found: adopt it when the request matched and work was outstanding, archive it otherwise. Both decisions are now the user's. The skill is loaded and run inside a single session, so anything already in the directory came from a different one, and it is the only record of a run the user paid for. Steps 3 and 4 become read, report, ask, then branch, with three answers: resume, start a new run and archive what is there, or stop so the old files can be read first. Only a directory with no run files of its own proceeds without a question, which covers an empty directory and one left holding an earlier archive. Resuming is offered only when the leftover tracker matches the request in hand, since resuming anything else would resend another request's prompt file to Ori.

The appendices no longer carry shell recipes. Deriving the run directory, archiving a previous run, and starting a run were each written as a command block, which fixed the mechanics and left the reason for them implicit. They now state the outcome and the constraints that make it correct, and the agent works out how. The run directory needs to resolve to the same place for one repository and never collide across repositories, on both Linux and macOS. Archiving must preserve every earlier archive and must not nest one inside itself. A run must use an unused attempt number, with the assistant text and the diagnostics kept apart, because the cost table is read back out of those files.

The naming convention for the directory stays stated in prose, since a later run can only find an earlier one if both follow it.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/19516f3da8cf4e5088674768554c1e9c
Requested by: @louisgv
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->