### PR TITLE
fix(spawn-ori-eval): show Ori's narration and keep status updates plain

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -163,7 +163,7 @@ Status updates the user sees must stay plain. Examples:
 | -- | -- |
 | Attempt 2 exited with a tagged question; see answer-2.txt. | Ori read your repo and has a question before it continues. |
 | Restarting ori code --prompt-file with n=3. | I sent your answer to Ori. It reads the project and the full story again, then continues from where it stopped. About 15 minutes. |
-| Background command "Restart Ori run as attempt 4 with priority answer" completed (exit code 0) | Ori has finished reading. I check what it came back with. |
+| Background command "Restart Ori run as attempt 4 with priority answer" completed (exit code 0) | Ori has finished reading. I am checking what it came back with. |
 | Process 48210 is running; error-1.log is empty. | The run continues. Silence is normal here. |
 | The run wrote no summary line. | The run stopped before it could report its time and cost. |
 
@@ -175,12 +175,12 @@ What you append afterwards is the question's full text in plain language plus th
 
 ## Appendix F: cost and timing table
 
-Include one row for every attempt, including each attempt that ended at a question, since a restart repeats repo exploration. Each attempt's duration and cost come from the summary line at the end of its answer file, and the eval's own model calls and judging come from Ori's closing table in the final answer. Start times are the operator's observation, because the summary line reports duration only. An attempt whose answer file has no summary line reported nothing, so mark it "unmeasured", which is not zero, and report the total as a floor whenever any row is unmeasured.
+Include one row for every attempt, including each attempt that ended at a question, since a restart repeats repo exploration. Each attempt's duration and cost come from the summary line at the end of its answer file, and the eval's own model calls and judging come from Ori's closing table in the final answer. Start times are the operator's observation, because the summary line reports duration only. An attempt whose answer file has no summary line reported nothing, so mark it "unmeasured", which is not zero, and report the total as a floor whenever any row is unmeasured. Label the rows in plain language, because the table goes to the user and the plain-language rule holds here too.
 
 | Step | Start | Duration | Cost |
 | -- | -- | -- | -- |
-| Attempt stopped at question 1 | observed 20:29 | 39s | $0.42 |
-| Restart and repeated exploration | observed 20:30 | 15m 10s | $3.20 |
+| Reading the project, stopped to ask you a question | observed 20:29 | 39s | $0.42 |
+| Reading the project again after your answer | observed 20:30 | 15m 10s | $3.20 |
 | Eval model calls | 20:46 | 2m | $0.46 |
 | Judging | 20:48 | 1m | $0.05 |
 | … |  |  |  |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -27,17 +27,18 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 14. Write the task prompt file (appendix C).
 15. Start one run from the repo root and capture its answer and error files (appendix D).
 16. Wait for the run to exit, then read the answer file (appendix E).
-17. If the completed answer contains a tagged question anywhere or its assistant text, above the summary line, ends on an untagged question, continue to step 18; relay only the first question, report a broken one-question contract if another appears, and report an untagged question as a violation while still restarting (appendix E).
-18. Show the first question text to the user as plain text.
-19. Ask the user with your own question UI, preserving the three options and free-text `Other`.
-20. Append the question and the user's answer to the task prompt file (appendix E).
-21. Restart over the whole prompt file with the next attempt number, then return to step 16.
-22. Relay the result table, the ship or no-ship decision, and the quoted failures.
-23. Relay Ori's cost and timing table in full (appendix F).
-24. Add each attempt's own duration and cost from the summary line at the end of its answer file (appendix F).
-25. Add one line on the cheaper cost of a re-run.
-26. Tell the user where Ori left the temporary workspace and that it is throwaway.
-27. Say they can move the eval into their repo if the numbers made them want to keep it.
+17. Show the user Ori's narration lines from the answer file in plain language, before the question or the result (appendix E).
+18. If the completed answer contains a tagged question anywhere or its assistant text, above the summary line, ends on an untagged question, continue to step 19; relay only the first question, report a broken one-question contract if another appears, and report an untagged question as a violation while still restarting (appendix E).
+19. Show the first question text to the user as plain text.
+20. Ask the user with your own question UI, preserving the three options and free-text `Other`.
+21. Append the question and the user's answer to the task prompt file (appendix E).
+22. Restart over the whole prompt file with the next attempt number, then return to step 16.
+23. Relay the result table, the ship or no-ship decision, and the quoted failures.
+24. Relay Ori's cost and timing table in full (appendix F).
+25. Add each attempt's own duration and cost from the summary line at the end of its answer file (appendix F).
+26. Add one line on the cheaper cost of a re-run.
+27. Tell the user where Ori left the temporary workspace and that it is throwaway.
+28. Say they can move the eval into their repo if the numbers made them want to keep it.
 
 ## Rules
 
@@ -53,7 +54,7 @@ These hold for the whole run.
 - Treat the run directory's `task.txt` as the only task prompt state. Append every later message to it, resend the whole file on every restart, never use `--session`, and keep one answer file and one error log per attempt.
 - Never ask the user what to eval before the run. Ori's interview covers the surface, success criteria, real data, cost limit, and baseline model. Pass a vague or empty request through unchanged.
 - Never answer Ori's question on the user's behalf. If you cannot reach the user, stop and wait. A guessed target produces an invalid eval that looks correct.
-- Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are the run directory choice in step 4 and the questions handled by step 17.
+- Do not invent an approval gate before starting the run. Steps 12 and 13 disclose the time and cost, and the only user pauses are the run directory choice in step 4 and the questions handled by step 18.
 - Each turn is silent from start to finish. Say that plainly before starting it. Do not report phase banners as milestones because they arrive only when the turn ends.
 - Never invent a number. Every attempt reports its own duration and cost on the summary line that ends its answer file, and the eval's own model calls come from Ori's closing table. Name a figure unmeasured only when the attempt wrote no summary line at all.
 - Never name a winner unless the production model is in the table. "No change" is a valid result.
@@ -65,6 +66,7 @@ These hold for the whole run.
 - Never put the eval inside the repo's own test framework. `ori eval` finds `*.eval.ts` files only, so a pytest, vitest, or Go test file silently never runs.
 - Never present raw API calls as an Ori eval. If you measure another way, label it clearly.
 - Never show the user this skill's vocabulary, including "pre-run", "spawn", "verbatim", and "harness".
+- Write each status update in plain language. Do not show attempt numbers, file paths, process IDs, command flags, or exit codes to the user. This rule also applies when a run fails. Appendix E gives examples.
 - Ori's interview has seven tags in this order: `[surface]`, `[workspace-files]`, `[workspace-data]`, `[criteria-priority]`, `[evaluation-constraint]`, `[candidates]`, and `[next-step]`. `[surface]` is conditional when the scan finds more than one call site. `[workspace-files]` is conditional only when the scan finds no model call site and no material to mine. The two conditional questions are mutually exclusive. The other five are always asked, so there are five questions at minimum and six at most.
 - Relay one question per turn. Preserve each question's three concrete options one for one and render `Other` as free text. If Ori emits two questions in one turn, relay only the first and report the one-question contract violation.
 - Never copy CLI details into this skill or into text for the user. Re-read what step 9 printed for run options, reports, baselines, timeouts, and the eval-file API, because the CLI changes and copies go stale.
@@ -150,6 +152,20 @@ summary  model=served/model  duration=200ms  input=100 tok  output=25 tok  conte
 ```
 
 Every attempt writes it, including one that stopped at a question, so it is where that attempt's duration and cost come from. A turn that died before finishing writes none. Read the question from the assistant text above it, since the summary line is what actually ends the file.
+
+The assistant text above the summary line contains Ori's narration: short plain lines that tell what it did, for example "Now scanning where this repo calls models, a few minutes." Show these lines to the user when the turn ends, before the question or the result. They tell the user what happened during the silence. If there are many lines, give a short summary. Keep Ori's own words when they are already plain.
+
+A restart is not a retry. Ori cannot hold a live conversation, so each answer starts a new session that re-reads the full prompt file and continues. Never show the words "restart" or "attempt" to the user, because they suggest a failure that did not happen.
+
+Status updates the user sees must stay plain. Examples:
+
+| Do not say | Say |
+| -- | -- |
+| Attempt 2 exited with a tagged question; see answer-2.txt. | Ori read your repo and has a question before it continues. |
+| Restarting ori code --prompt-file with n=3. | I sent your answer to Ori. It reads the project and the full story again, then continues from where it stopped. About 15 minutes. |
+| Background command "Restart Ori run as attempt 4 with priority answer" completed (exit code 0) | Ori has finished reading. I check what it came back with. |
+| Process 48210 is running; error-1.log is empty. | The run continues. Silence is normal here. |
+| The run wrote no summary line. | The run stopped before it could report its time and cost. |
 
 A finished turn ends its assistant text either on a question or on the final report. Find question tags anywhere in the completed answer text, and treat any narration after the first question as noise rather than evidence that the turn continued past it. Relay only the first question when a turn contains more than one, report the one-question contract violation, append the first answer, and restart. An untagged question at the end of the assistant text is also relayed, appended, and followed by a restart, with the contract violation reported alongside it. Show the first question and its three options to the user, ask with the operator's own question UI, keep `Other` as free text, append the question and the answer to `task.txt`, then restart with the next attempt number. Do not answer the question yourself. If Ori answered its own scoping question instead, discard that attempt rather than relaying it as a result, ask the user, append the answer, and restart.
 


### PR DESCRIPTION
Fixes [ORI-972](https://linear.app/openrouter/issue/ORI-972/user-facing-progress-feedback-during-spawn-ori-eval-runs-is-too).

What reached the user during a run was too technical and sparse. Ori writes plain-language narration in its answer, but the skill never told the orchestrator to show it, so the user got headlines only. The orchestrator's own updates also drifted into infra vocabulary (attempt numbers, file paths, exit codes), especially on failures.

## Changes

- **New step 17**: show Ori's narration lines from the answer file in plain language, before the question or the result. Later steps renumbered 18–28, cross-references updated.
- **New rule**: status updates stay in plain language, with no attempt numbers, file paths, process IDs, command flags, or exit codes, including when a run fails.
- **Appendix E**: explain that a restart is not a retry (each answer starts a new session that re-reads the full prompt file), ban the words "restart" and "attempt" in user-facing text, and add a do-not-say / say table of examples, including the common `Background command "Restart Ori run as attempt 4..." completed (exit code 0)` case.
- **Appendix F**: the cost table is shown to the user, so its example rows no longer say "Attempt" or "Restart", and the appendix now states that row labels follow the plain-language rule.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/0074e67571e64a9ebb277f5d331d6ada
Requested by: @jackyliang-openrouter