### PR TITLE
docs(spawn-ori-eval): pass the run directory into the task prompt

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -131,13 +131,15 @@ questions in one turn.
 User request: <verbatim request>
 Repo context pointers: <paths>. Read these first.
 
-The Ori directory is <absolute run directory>/ori. Keep the step tracker and
-every file you write outside the scratch workspace under that directory.
-Record the scratch workspace path Ori reports in the tracker directory. Do not
-derive another tracker path, and do not adopt or
-resume tracker state outside it. Use only the scratch workspace path reported
-by create-eval's own surface. Anything else outside this directory belongs to
-a different session. Run the eval with ori eval. Do not create or modify
+The Ori directory is <absolute run directory>/ori. Create it if it is absent.
+Keep the step tracker and every file you write outside the scratch workspace
+under that directory. Record the scratch workspace path you report in the
+tracker directory. Do not derive another tracker path, and do not adopt or
+resume tracker state outside it. The scratch workspace path you report is the
+only other location this run may use for its eval and supporting files. Any
+other tracker or state files outside these locations belong to a different
+session. Keep the eval and supporting files in that scratch workspace outside
+the user's repository. Run the eval with ori eval. Do not create or modify
 anything in the user's repository.
 ```
 
@@ -207,7 +209,7 @@ Follow it with one line, for example: the run cost $4.13 in total, and a rerun c
 | Ori does nothing and the prompt looks empty | The path in the start command does not match the file you wrote. |
 | Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
 | The eval file is inside the user's repository | Move it and its supporting files to a temporary workspace and run `ori eval` on the new path. |
-| Ori resumed a tracker of its own from an earlier session | Discard that attempt rather than relaying it. Tell the user what Ori found and where it is, then use step 4 to ask what to do before moving anything. Restart only after the user chooses. |
+| Ori resumed a tracker of its own from an earlier session | Discard that attempt rather than relaying it. Tell the user plainly that Ori resumed state from an earlier session, and ask before anything moves. When they agree, move only the leftover `ori/` state under `previous/<timestamp>/`, leave the current tracker, prompt file, and cost table intact, then restart from the full prompt file with the next attempt number. |
 | Ori picked the target itself | Discard the attempt rather than accepting the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
 | The answer has no tagged question but the run looks stopped | Read the final answer. Relay an untagged question, report the contract violation, append the answer, and restart. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -77,7 +77,7 @@ What you need is one scratch directory outside the user's repository whose name 
 
 The name has to be reproducible to the byte, because a later run of this skill finds the earlier one by arriving at the same path rather than by searching. So it is `/tmp/spawn-ori-eval-<hash>`, where the hash is the first twelve characters of the hexadecimal SHA-256 of exactly the repository root path, with no trailing newline and nothing else fed in. Only that value is pinned, not how you compute it, but it is worth checking that whatever you reach for hashes those bytes and no others, since a trailing newline produces a different directory and hides an earlier run. `/tmp` rather than whatever the environment calls the temporary directory, since that varies between machines and would hide a run from the next session on the same one.
 
-Every file the run produces lives there and nowhere else: `steps.txt`, `task.txt`, and each attempt's `answer-<n>.txt` and `error-<n>.log`. The directory is per repository, so two repos evaluated on one machine never read each other's prompt or answer.
+Every file the outer run produces lives there and nowhere else: `steps.txt`, `task.txt`, and each attempt's `answer-<n>.txt` and `error-<n>.log`. The `ori/` subdirectory is reserved for Ori's tracker and every file the run writes itself. The scratch workspace is created elsewhere by `ori eval scratch`, so record its reported path in `ori/`. The directory is per repository, so two repos evaluated on one machine never read each other's prompt or answer.
 
 `steps.txt` carries the user's request on its first line and then one line for each step from 5 onward, each marked `todo`, `current`, or `done`. Steps 1 to 4 are not tracked, because they are what produce the file.
 
@@ -90,17 +90,17 @@ request: which model should we use for the support triage agent
 16 todo wait for it to exit and read the answer file
 ```
 
-A directory with no run files of its own needs no question, because there is nothing to decide about. That covers a directory that is empty and one that holds only an earlier archive, since archiving leaves `previous/` behind for good. Everything else goes to the user, whatever it holds. A tracker started for a different request, or one whose every step is done, is a reason to tell the user what they are looking at rather than a licence to clear it, because the answer files are the run they paid for and they may want to read them before anything moves.
+A directory with no run files of its own needs no question, because there is nothing to decide about. That means it is empty apart from `previous/` and has no `steps.txt`, `task.txt`, attempt files, or `ori/` subdirectory. This covers a directory that is empty and one that holds only an earlier archive, since archiving leaves `previous/` behind for good. Everything else goes to the user, whatever it holds. A tracker started for a different request, or one whose every step is done, is a reason to tell the user what they are looking at rather than a licence to clear it, because the answer files are the run they paid for and they may want to read them before anything moves.
 
 So read the directory and report it. Give the user what they need to decide without opening it themselves: the request the old tracker was started for, the step it stopped at in plain language, how many attempts ran, and how long ago the last one wrote anything. Then ask with the operator's own question UI and wait.
 
 Offer resuming only when the old tracker's first line matches the request you are working on and a step is unfinished. Resuming anything else would resend another request's prompt file to Ori. Starting a new run and stopping are always available, so the question has three answers at most and two at least.
 
-Resuming reuses what is there as it stands: mark up the same `steps.txt`, append to the same `task.txt`, and keep every earlier attempt in the cost table, because the user already paid for that work. Starting a new run archives the tracker, the prompt file, and every answer and error log, which drops the answers the user already gave Ori and pays for the repo exploration again. Stopping changes nothing and ends the task there, which is what the user wants when they would rather read the old files before anything moves. Say which one you are recommending and why, and let them decide.
+Resuming reuses what is there as it stands: mark up the same `steps.txt`, append to the same `task.txt`, keep every earlier attempt in the cost table, and keep the `ori/` directory with its recorded scratch workspace path, because the user already paid for that work. Starting a new run archives the tracker, the prompt file, every answer and error log, and the `ori/` directory, which drops the answers the user already gave Ori and pays for the repo exploration again. Stopping changes nothing and ends the task there, which is what the user wants when they would rather read the old files before anything moves. Say which one you are recommending and why, and let them decide.
 
 One thing to settle before resuming: a step left marked `current` means an attempt was started and its outcome is unknown. Establish whether that process is still running before starting another, and wait for it if it is, because two runs against the same prompt file break the one-process rule.
 
-Archiving means the old run's files end up under `previous/` inside the run directory, in their own subdirectory named after the time they were moved, and nothing is deleted. Two things go wrong without the timestamp: a later archive overwrites an earlier one, and the archive directory gets moved inside itself. So move the run's own files and leave `previous/` where it is.
+Archiving means the old run's files, including `ori/`, end up under `previous/` inside the run directory, in their own subdirectory named after the time they were moved, and nothing is deleted. Two things go wrong without the timestamp: a later archive overwrites an earlier one, and the archive directory gets moved inside itself. So move the run's own files and leave `previous/` where it is.
 
 ## Appendix B: setup commands
 
@@ -131,13 +131,14 @@ questions in one turn.
 User request: <verbatim request>
 Repo context pointers: <paths>. Read these first.
 
-The run directory is <absolute run directory>. It is the temporary workspace
-outside the user's repository. Keep the step tracker, scratch workspace, eval,
-supporting files, and everything else you write under that directory. Do not
-derive another path elsewhere, and do not adopt or resume a tracker or
-workspace outside it. Anything outside this directory belongs to a different
-session. Run the eval with ori eval. Do not create or modify anything in the
-user's repository.
+The Ori directory is <absolute run directory>/ori. Keep the step tracker and
+every file you write outside the scratch workspace under that directory.
+Record the scratch workspace path reported by `ori eval scratch` in the
+tracker directory. Do not derive another tracker path, and do not adopt or
+resume tracker state outside it. Use only the scratch workspace path reported
+by `ori eval scratch`. Anything else outside this directory belongs to a
+different session. Run the eval with ori eval. Do not create or modify anything
+in the user's repository.
 ```
 
 ## Appendix D: starting a run
@@ -206,7 +207,7 @@ Follow it with one line, for example: the run cost $4.13 in total, and a rerun c
 | Ori does nothing and the prompt looks empty | The path in the start command does not match the file you wrote. |
 | Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
 | The eval file is inside the user's repository | Move it and its supporting files to a temporary workspace and run `ori eval` on the new path. |
-| Ori resumed a tracker of its own from an earlier session | Discard that attempt rather than relaying it. Tell the user plainly, then restart from the full prompt file, because the answers it carried forward belong to a different request. |
+| Ori resumed a tracker of its own from an earlier session | Discard that attempt rather than relaying it. Tell the user plainly, archive the leftover Ori state, then restart from the full prompt file, because the answers it carried forward belong to a different request. |
 | Ori picked the target itself | Discard the attempt rather than accepting the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
 | The answer has no tagged question but the run looks stopped | Read the final answer. Relay an untagged question, report the contract violation, append the answer, and restart. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -77,7 +77,7 @@ What you need is one scratch directory outside the user's repository whose name 
 
 The name has to be reproducible to the byte, because a later run of this skill finds the earlier one by arriving at the same path rather than by searching. So it is `/tmp/spawn-ori-eval-<hash>`, where the hash is the first twelve characters of the hexadecimal SHA-256 of exactly the repository root path, with no trailing newline and nothing else fed in. Only that value is pinned, not how you compute it, but it is worth checking that whatever you reach for hashes those bytes and no others, since a trailing newline produces a different directory and hides an earlier run. `/tmp` rather than whatever the environment calls the temporary directory, since that varies between machines and would hide a run from the next session on the same one.
 
-Every file the outer run produces lives there and nowhere else: `steps.txt`, `task.txt`, and each attempt's `answer-<n>.txt` and `error-<n>.log`. The `ori/` subdirectory is reserved for Ori's tracker and every file the run writes itself. The scratch workspace is created elsewhere by `ori eval scratch`, so record its reported path in `ori/`. The directory is per repository, so two repos evaluated on one machine never read each other's prompt or answer.
+Every file the outer run produces lives there and nowhere else: `steps.txt`, `task.txt`, and each attempt's `answer-<n>.txt` and `error-<n>.log`. The `ori/` subdirectory is reserved for Ori's tracker and every file the run writes itself. The scratch workspace is wherever create-eval's own surface puts it, so record the path Ori reports in `ori/`. The directory is per repository, so two repos evaluated on one machine never read each other's prompt or answer.
 
 `steps.txt` carries the user's request on its first line and then one line for each step from 5 onward, each marked `todo`, `current`, or `done`. Steps 1 to 4 are not tracked, because they are what produce the file.
 
@@ -133,12 +133,12 @@ Repo context pointers: <paths>. Read these first.
 
 The Ori directory is <absolute run directory>/ori. Keep the step tracker and
 every file you write outside the scratch workspace under that directory.
-Record the scratch workspace path reported by `ori eval scratch` in the
-tracker directory. Do not derive another tracker path, and do not adopt or
+Record the scratch workspace path Ori reports in the tracker directory. Do not
+derive another tracker path, and do not adopt or
 resume tracker state outside it. Use only the scratch workspace path reported
-by `ori eval scratch`. Anything else outside this directory belongs to a
-different session. Run the eval with ori eval. Do not create or modify anything
-in the user's repository.
+by create-eval's own surface. Anything else outside this directory belongs to
+a different session. Run the eval with ori eval. Do not create or modify
+anything in the user's repository.
 ```
 
 ## Appendix D: starting a run
@@ -207,7 +207,7 @@ Follow it with one line, for example: the run cost $4.13 in total, and a rerun c
 | Ori does nothing and the prompt looks empty | The path in the start command does not match the file you wrote. |
 | Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
 | The eval file is inside the user's repository | Move it and its supporting files to a temporary workspace and run `ori eval` on the new path. |
-| Ori resumed a tracker of its own from an earlier session | Discard that attempt rather than relaying it. Tell the user plainly, archive the leftover Ori state, then restart from the full prompt file, because the answers it carried forward belong to a different request. |
+| Ori resumed a tracker of its own from an earlier session | Discard that attempt rather than relaying it. Tell the user what Ori found and where it is, then use step 4 to ask what to do before moving anything. Restart only after the user chooses. |
 | Ori picked the target itself | Discard the attempt rather than accepting the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
 | The answer has no tagged question but the run looks stopped | Read the final answer. Relay an untagged question, report the contract violation, append the answer, and restart. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -114,6 +114,9 @@ Run `ori auth` before starting. It resolves the credential the CLI will use, inc
 
 Write this to `task.txt` in the run directory, filling in every angle-bracket field.
 
+Pass the run directory into the prompt so the outer run can archive every
+file it owns and still start the next session cleanly.
+
 ```text
 Use the create-eval skill. Follow its five phases in this order: workspace
 context, criteria and narrowing, bakeoff, routing, close. There are seven
@@ -128,9 +131,13 @@ questions in one turn.
 User request: <verbatim request>
 Repo context pointers: <paths>. Read these first.
 
-Keep the eval and any supporting files in a temporary workspace outside the
-user's repository. Run it with ori eval. Do not create or modify anything in
-the user's repository.
+The run directory is <absolute run directory>. It is the temporary workspace
+outside the user's repository. Keep the step tracker, scratch workspace, eval,
+supporting files, and everything else you write under that directory. Do not
+derive another path elsewhere, and do not adopt or resume a tracker or
+workspace outside it. Anything outside this directory belongs to a different
+session. Run the eval with ori eval. Do not create or modify anything in the
+user's repository.
 ```
 
 ## Appendix D: starting a run
@@ -199,6 +206,7 @@ Follow it with one line, for example: the run cost $4.13 in total, and a rerun c
 | Ori does nothing and the prompt looks empty | The path in the start command does not match the file you wrote. |
 | Ori reports that a model id is not available | Tell Ori to find the id again. Do not supply one from memory. |
 | The eval file is inside the user's repository | Move it and its supporting files to a temporary workspace and run `ori eval` on the new path. |
+| Ori resumed a tracker of its own from an earlier session | Discard that attempt rather than relaying it. Tell the user plainly, then restart from the full prompt file, because the answers it carried forward belong to a different request. |
 | Ori picked the target itself | Discard the attempt rather than accepting the guessed target. Ask the user, append the answer, and restart from the full prompt file. |
 | The answer has no tagged question but the run looks stopped | Read the final answer. Relay an untagged question, report the contract violation, append the answer, and restart. |
 | `403 Key limit exceeded` or a 402 payment error | The key is at its spend limit. See below. |


### PR DESCRIPTION
## Summary

The task prompt never told Ori where the run directory was, so Ori derived its own state path and adopted whatever it found there. In a real run it picked up a tracker left by an earlier, unrelated session, skipped its scoping interview, and carried forward answers from a different request, while this skill believed it had archived everything and started clean.

Appendix C now names an Ori-owned subdirectory of the run directory and makes it the one place Ori keeps state. The subdirectory rather than the run root, because the outer skill reserves `steps.txt`, `task.txt` and the attempt files there and a shared flat namespace would let the two trackers clobber each other:

```text
The Ori directory is <absolute run directory>/ori. Create it if it is absent.
Keep the step tracker and every file you write outside the scratch workspace
under that directory. Record the scratch workspace path you report in the
tracker directory. Do not derive another tracker path, and do not adopt or
resume tracker state outside it. The scratch workspace path you report is the
only other location this run may use for its eval and supporting files. Any
other tracker or state files outside these locations belong to a different
session. Keep the eval and supporting files in that scratch workspace outside
the user's repository. Run the eval with ori eval. Do not create or modify
anything in the user's repository.
```

Three details in that wording are deliberate. The scratch workspace stays wherever create-eval puts it, because the command that creates it takes no arguments, so its path is recorded rather than chosen. No command name appears, because this skill forbids copying CLI details into itself and an older binary may not expose the same surface. The exclusion is scoped to tracker and state files, so a restarted run reading this prompt again cannot disown the scratch workspace holding its own eval.

Appendix A is updated so the new state is actually governed: `ori/` is in the file inventory, it counts as run files when deciding whether the directory holds anything, and archiving moves it under `previous/<timestamp>/` with the rest. Without that, a fresh start would leave Ori's tracker behind and reintroduce the bug.

Appendix G gains one row for the symptom the user hit. It discards the attempt, says in plain language that Ori resumed earlier state, and asks before anything moves. What then moves is only the leftover `ori/` state, because the run in progress owns its tracker, prompt file and cost table and the user paid for them.

The wording stands on its own as an instruction, because an older `ori` binary ships an older `create-eval` that still derives its own path by default. The matching change on the Ori side is OpenRouterIncubator/ori#1681.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/9c2f5954fc7d4170a22c7a19e6540872
Requested by: @louisgv
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->