### PR TITLE
docs(spawn-ori-eval): trim the pins section to one sentence

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -9,10 +9,10 @@ Ori writes and grades the eval on a pinned harness and model, so the bench is id
 
 ## Pins
 
-These two slugs are written down only here, and everywhere else in this skill `<RUN_MODEL>` and `<JUDGE_MODEL>` stand in for them exactly as written, so swapping a model is an edit to the two lines below and nothing else.
+This section gives the two models. The other sections use the names `<RUN_MODEL>` and `<JUDGE_MODEL>`. Replace each name with the model that this section gives. To change a model, change only the two lines that follow.
 
-- `RUN_MODEL` is `openai/gpt-5.6-terra`, the model the run itself uses.
-- `JUDGE_MODEL` is `openai/gpt-5.6-terra`, the model the eval judges with.
+- `RUN_MODEL` is `openai/gpt-5.6-terra`. The run uses this model.
+- `JUDGE_MODEL` is `openai/gpt-5.6-terra`. The eval judge uses this model.
 
 ## Steps
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -9,14 +9,10 @@ Ori writes and grades the eval on a pinned harness and model, so the bench is id
 
 ## Pins
 
-This section is the only place either model slug is written down. It works like a block of constants: the rest of this skill refers to these two names and never to a slug, and wherever you see `<RUN_MODEL>` or `<JUDGE_MODEL>` in a rule, a command, or the task prompt template, you substitute the exact slug below, character for character, with no prefix, suffix, or version added.
+These two slugs are written down only here, and everywhere else in this skill `<RUN_MODEL>` and `<JUDGE_MODEL>` stand in for them exactly as written, so swapping a model is an edit to the two lines below and nothing else.
 
-- `RUN_MODEL` is `openai/gpt-5.6-terra`. Pass it to `ori code` as `--model` on every start and restart. It is the model Ori itself runs on while it reads the repository and writes the eval.
-- `JUDGE_MODEL` is `openai/gpt-5.6-terra`. Put it in the task prompt so the eval judges with it instead of the SDK's default. It is not one of the models under test.
-
-Neither value is yours to choose. Do not pick a different model because it seems better, cheaper, faster, or newer, do not ask the user which model to use, and do not let a model mentioned in the user's request replace either one. The models being compared inside the eval are a separate matter, chosen during the run, and they never change these two.
-
-Changing what a run costs is therefore one edit to the two lines above, and nothing else in this file needs to move.
+- `RUN_MODEL` is `openai/gpt-5.6-terra`, the model the run itself uses.
+- `JUDGE_MODEL` is `openai/gpt-5.6-terra`, the model the eval judges with.
 
 ## Steps
 


### PR DESCRIPTION
## Summary

The `Pins` section merged in #136 grew three paragraphs of justification and prohibitions. This cuts it back to four short sentences and the two constant lines, written in ASD-STE100 Simplified Technical English: one idea per sentence, active voice, imperative instructions.

```text
This section gives the two models. The other sections use the names
`<RUN_MODEL>` and `<JUDGE_MODEL>`. Replace each name with the model that this
section gives. To change a model, change only the two lines that follow.
```

No behavior change: both slugs and the places that reference them are untouched.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/6bd1038f85144c3cb8d7b397a024bb74
Requested by: @jackyliang-openrouter