### PR TITLE
fix(spawn-ori-eval): pipe the Ori installer into bash

### DIFF
--- a/skills/install-ori-harness/SKILL.md
+++ b/skills/install-ori-harness/SKILL.md
@@ -16,7 +16,7 @@ Ori.
 Run the official installer:
 
 ```sh
-curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh
+curl -fsSL https://openrouter.ai/labs/ori/install.sh | bash
 ```
 
 The installer puts the `ori` executable in the user's local install location.

--- a/skills/spawn-ori-eval/README.md
+++ b/skills/spawn-ori-eval/README.md
@@ -16,7 +16,7 @@ For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) s
 
 ## Prerequisites
 
-- `ori` on PATH — `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`
+- `ori` on PATH — `curl -fsSL https://openrouter.ai/labs/ori/install.sh | bash`
 - OpenRouter access resolved by `ori auth`; sign in with `ori login` if needed
 - [Bun](https://bun.sh), which Ori uses to execute `*.eval.ts`
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -111,7 +111,7 @@ Archiving means the old run's files end up under `previous/` inside the run dire
 
 ## Appendix B: setup commands
 
-Install the binary with `curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh`. It lands in `~/.local/bin`, which is frequently absent from PATH in a non-login shell, so try `~/.local/bin/ori --version` before reporting a failure. Bun is required because Ori executes `*.eval.ts` with it.
+Install the binary with `curl -fsSL https://openrouter.ai/labs/ori/install.sh | bash`. It lands in `~/.local/bin`, which is frequently absent from PATH in a non-login shell, so try `~/.local/bin/ori --version` before reporting a failure. Bun is required because Ori executes `*.eval.ts` with it.
 
 Read the eval surface with `ori eval -h` and `ori eval skill`, falling back to `ori skills get create-eval` if the second errors. This is what Ori itself follows inside the run, so it tells you what the run will do and which questions it will ask. It never blocks the task: if both commands error, carry on.
 


### PR DESCRIPTION
## Summary

The Ori install command published in these skills cannot run on Debian or Ubuntu, so an agent that follows the preflight step installs nothing and reports a syntax error.

The script served at `openrouter.ai/labs/ori/install.sh` declares `#!/usr/bin/env bash` and uses Bash arithmetic. On Debian and Ubuntu `/bin/sh` is Dash, which rejects the whole file at parse time, before any installation happens. The script's own usage comment says to pipe into `bash`.

```
$ curl -fsSL https://openrouter.ai/labs/ori/install.sh -o ori-install.sh
$ bash -n ori-install.sh; echo $?
0
$ sh -n ori-install.sh
ori-install.sh: 480: Syntax error: Missing '))'
```

Changed in `skills/spawn-ori-eval/SKILL.md`, `skills/spawn-ori-eval/README.md`, and `skills/install-ori-harness/SKILL.md`:

```diff
-curl -fsSL https://openrouter.ai/labs/ori/install.sh | sh
+curl -fsSL https://openrouter.ai/labs/ori/install.sh | bash
```

A repository-wide scan found no other Ori installer occurrence.

The same command shipped from the web surfaces (`/ori/eval`, `/ori/harness`, `/ori/code`, and the pending docs guide) is fixed in OpenRouterTeam/openrouter-web#31690. ORI-940 is commented, because its create-eval refactor spec carries the broken form and would otherwise reintroduce it.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/eef95bbb38584ba69ebc8adf85a3e4e9
Requested by: @jackyliang-openrouter