### PR TITLE
docs(spawn-ori-eval): say model comparison instead of bakeoff ORI-981

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -123,9 +123,8 @@ Write this to `task.txt` in the run directory, filling in every angle-bracket fi
 
 ```text
 Use the create-eval skill. Follow its five phases in this order: workspace
-context, criteria and narrowing, model comparison, routing, close.
-There are seven
-possible question tags in this order: `[surface]`, `[workspace-files]`,
+context, criteria and narrowing, model comparison, routing, close. There are
+seven possible question tags in this order: `[surface]`, `[workspace-files]`,
 `[workspace-data]`, `[criteria-priority]`, `[evaluation-constraint]`,
 `[candidates]`, and `[next-step]`. The first two are mutually exclusive
 conditional questions, so each run asks five or six questions.

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -123,7 +123,8 @@ Write this to `task.txt` in the run directory, filling in every angle-bracket fi
 
 ```text
 Use the create-eval skill. Follow its five phases in this order: workspace
-context, criteria and narrowing, model comparison, routing, close. There are seven
+context, criteria and narrowing, model comparison, routing, close.
+There are seven
 possible question tags in this order: `[surface]`, `[workspace-files]`,
 `[workspace-data]`, `[criteria-priority]`, `[evaluation-constraint]`,
 `[candidates]`, and `[next-step]`. The first two are mutually exclusive

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spawn-ori-eval
-description: Spawn Ori as a subprocess to run a throwaway model eval on a pinned harness and model, then relay the results. Use when the user asks which model they should use, wants to compare or bake off models, wants to measure whether their agent or prompt does the right thing, wants to catch regressions in agent behavior, or asks how good their current model is. Applies to any codebase in any language. Do not use for plain unit tests that involve no model, and do not use to re-run an eval that already exists (run `ori eval <file>` directly).
+description: Spawn Ori as a subprocess to run a throwaway model eval on a pinned harness and model, then relay the results. Use when the user asks which model they should use, wants to compare models, wants to measure whether their agent or prompt does the right thing, wants to catch regressions in agent behavior, or asks how good their current model is. Applies to any codebase in any language. Do not use for plain unit tests that involve no model, and do not use to re-run an eval that already exists (run `ori eval <file>` directly).
 ---
 
 # Spawn Ori Eval
@@ -123,7 +123,7 @@ Write this to `task.txt` in the run directory, filling in every angle-bracket fi
 
 ```text
 Use the create-eval skill. Follow its five phases in this order: workspace
-context, criteria and narrowing, bakeoff, routing, close. There are seven
+context, criteria and narrowing, model comparison, routing, close. There are seven
 possible question tags in this order: `[surface]`, `[workspace-files]`,
 `[workspace-data]`, `[criteria-priority]`, `[evaluation-constraint]`,
 `[candidates]`, and `[next-step]`. The first two are mutually exclusive


### PR DESCRIPTION
## Summary

ORI-981: "bakeoff" is jargon that means nothing to someone meeting the eval flow for the first time, so this drops it from `spawn-ori-eval` in favor of plain language.

Two wording changes, no behavior:

- The skill description now says the user "wants to compare models" rather than "wants to compare or bake off models", which keeps the trigger coverage without the term.
- The phase list in the `task.txt` template names phase 3 "model comparison", matching the renamed phase the `create-eval` skill now announces in [ori#1685](https://github.com/OpenRouterIncubator/ori/pull/1685). The block is hard-wrapped, so the surrounding line was rewrapped to keep the wrap width.

Tag names such as `[candidates]` and every CLI invocation are untouched.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/d911203be4e64503a9af642979778886
Requested by: @jackyliang-openrouter