### PR TITLE
fix(spawn-ori-eval): require placement 2 for the [next-step] question

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -36,7 +36,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 16. Wait for the run to exit, then read the answer file (appendix E).
 17. Show the user Ori's narration lines from the answer file in plain language, and use a safe placement when a question follows (appendix E).
 18. If the completed answer contains a tagged question anywhere or its assistant text, above the summary line, ends on an untagged question, continue to step 19; relay only the first question, report a broken one-question contract if another appears, and report an untagged question as a violation while still restarting (appendix E).
-19. Put the question's full text, including its context table, inside the question UI itself (appendix E).
+19. Put the question's full text, including its context table, inside the question UI itself; for `[next-step]`, use placement 2 instead (appendix E).
 20. Ask the user with your own question UI, preserving the three options and free-text `Other`.
 21. Append the question and the user's answer to the task prompt file (appendix E).
 22. Restart over the whole prompt file with the next attempt number, then return to step 16.
@@ -77,7 +77,7 @@ These hold for the whole run.
 - Write each status update in plain language. Do not show attempt numbers, file paths, process IDs, command flags, or exit codes to the user. This rule also applies when a run fails. Appendix E gives examples.
 - Ori's interview has seven tags in this order: `[surface]`, `[workspace-files]`, `[workspace-data]`, `[criteria-priority]`, `[evaluation-constraint]`, `[candidates]`, and `[next-step]`. `[surface]` is conditional when the scan finds more than one call site. `[workspace-files]` is conditional only when the scan finds no model call site and no material to mine. The two conditional questions are mutually exclusive. The other five are always asked, so there are five questions at minimum and six at most.
 - Relay one question per turn. Preserve each question's three concrete options one for one and render `Other` as free text. If Ori emits two questions in one turn, relay only the first and report the one-question contract violation.
-- Never put any content in text, or in a file, before a question-UI call in the same turn. Some hosts show none of it — narration and evidence alike — and the user answers without it. This applies to every question, including `[next-step]`, to the results tables, and to step 17's narration lines. Appendix E gives the two safe placements.
+- Never put any content in text, or in a file, before a question-UI call in the same turn. Some hosts show none of it — narration and evidence alike — and the user answers without it. This applies to every question, including `[next-step]`, to the results tables, and to step 17's narration lines. Appendix E gives the two safe placements. For `[next-step]`, placement 2 is mandatory, so the full results tables stand above the question.
 - Never copy CLI details into this skill or into text for the user. Re-read what step 9 printed for run options, reports, baselines, timeouts, and the eval-file API, because the CLI changes and copies go stale.
 
 ## Appendix A: run directory and step tracker
@@ -186,6 +186,8 @@ A question is not only its labels. It carries context the labels do not, such as
 
 1. Put the question's full text, including its table, inside the question UI: in the question text, or in option previews when the UI has them. Put step 17's narration lines there too, ahead of the question text.
 2. If your question UI cannot carry the table, end your turn with the narration and the table as the final text and say the question comes next. Ask with the question UI in your next turn.
+
+For `[next-step]`, use placement 2 even when the question UI can carry a table. The full results table and the cost table are the report the user paid for. They must stand in the conversation above the question, not compressed into a picker.
 
 Keep the three options one for one, keep `Other` as free text, and translate the wording into simple language.
 


### PR DESCRIPTION
Follow-up to [ORI-980](https://linear.app/openrouter/issue/ORI-980/spawn-ori-eval-context-tables-shown-before-the-question-ui-never-reach) / #140.

Field report after #140: at the `[next-step]` gate the operator used placement 1 — results summary inside the picker, "full report follows after this question". Safe, but the user answers the closing question from a summary instead of the full report.

Placement 2 (turn-final tables, question asked in the next turn) is now **mandatory for `[next-step]`**: the full results table and cost table must stand in the conversation above the question. Interview questions keep placement 1 (no extra round trip where a table fits in the picker).

Three edits: step 19, the same-turn rule, and appendix E.