### PR TITLE
fix(spawn-ori-eval): never put a table in question text; placement 2 for all tabled questions

### DIFF
--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -36,7 +36,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 16. Wait for the run to exit, then read the answer file (appendix E).
 17. Show the user Ori's narration lines from the answer file in plain language, and use a safe placement when a question follows (appendix E).
 18. If the completed answer contains a tagged question anywhere or its assistant text, above the summary line, ends on an untagged question, continue to step 19; relay only the first question, report a broken one-question contract if another appears, and report an untagged question as a violation while still restarting (appendix E).
-19. Put the question's full text, including its context table, inside the question UI itself; for `[next-step]`, use placement 2 instead (appendix E).
+19. Put the question's prose, but never a table, inside the question UI; when the question carries a table, use placement 2 (appendix E).
 20. Ask the user with your own question UI, preserving the three options and free-text `Other`.
 21. Append the question and the user's answer to the task prompt file (appendix E).
 22. Restart over the whole prompt file with the next attempt number, then return to step 16.
@@ -78,7 +78,7 @@ These hold for the whole run.
 - Write each status update in plain language. Do not show attempt numbers, file paths, process IDs, command flags, or exit codes to the user. This rule also applies when a run fails. Appendix E gives examples.
 - Ori's interview has seven tags in this order: `[surface]`, `[workspace-files]`, `[workspace-data]`, `[criteria-priority]`, `[evaluation-constraint]`, `[candidates]`, and `[next-step]`. `[surface]` is conditional when the scan finds more than one call site. `[workspace-files]` is conditional only when the scan finds no model call site and no material to mine. The two conditional questions are mutually exclusive. The other five are always asked, so there are five questions at minimum and six at most.
 - Relay one question per turn. Preserve each question's three concrete options one for one and render `Other` as free text. If Ori emits two questions in one turn, relay only the first and report the one-question contract violation.
-- Never put any content in text, or in a file, before a question-UI call in the same turn. Some hosts show none of it — narration and evidence alike — and the user answers without it. This applies to every question, including `[next-step]`, to the results tables, and to step 17's narration lines. Appendix E gives the two safe placements. For `[next-step]`, placement 2 is mandatory, so the full results tables stand above the question.
+- Never put any content in text, or in a file, before a question-UI call in the same turn. Some hosts show none of it — narration and evidence alike — and the user answers without it. This applies to every question, including `[next-step]`, to the results tables, and to step 17's narration lines. Appendix E gives the two safe placements. Placement 2 is mandatory for `[next-step]` and for every question that carries a table, so each table stands above its question.
 - Never copy CLI details into this skill or into text for the user. Re-read what step 9 printed for run options, reports, baselines, timeouts, and the eval-file API, because the CLI changes and copies go stale.
 
 ## Appendix A: run directory and step tracker
@@ -186,10 +186,10 @@ A finished turn ends its assistant text either on a question or on the final rep
 
 A question is not only its labels. It carries context the labels do not, such as the markdown table of surface and current model, and the user must see that context at answer time. Text or files sent before a question-UI call in the same turn can be dropped by the host and never reach the user. Two placements are safe:
 
-1. Put the question's full text, including its table, inside the question UI: in the question text, or in option previews when the UI has them. Put step 17's narration lines there too, ahead of the question text.
-2. If your question UI cannot carry the table, end your turn with the narration and the table as the final text and say the question comes next. Ask with the question UI in your next turn.
+1. Put the question's prose inside the question UI: in the question text, or in option previews when the UI has them. Put step 17's narration lines there too, ahead of the question text. Never put a markdown table in the question text. Question UIs show it as raw pipe characters, which the user cannot read.
+2. End your turn with the narration and the table as the final text and say the question comes next. Ask with the question UI in your next turn.
 
-For `[next-step]`, use placement 2 even when the question UI can carry a table. The full results table and the cost table are the report the user paid for. They must stand in the conversation above the question, not compressed into a picker.
+Placement 2 is mandatory for every question that carries a table, and always for `[next-step]`. The full results table and the cost table are the report the user paid for. They must stand in the conversation above the question, not compressed into a picker.
 
 Keep the three options one for one, keep `Other` as free text, and translate the wording into simple language.
 


### PR DESCRIPTION
Third iteration on [ORI-980](https://linear.app/openrouter/issue/ORI-980/spawn-ori-eval-context-tables-shown-before-the-question-ui-never-reach) (reopened), after #140 and #142.

## Field report

With placement 1, the operator embedded the `[surface]` inventory table in the question body — and Claude Code's question UI rendered it as raw pipe characters. The table survives, but the user can't read it.

## Changes

- **Step 19**: question UI carries prose only, never a table; a tabled question uses placement 2.
- **Rule**: placement 2 mandatory for `[next-step]` and every question that carries a table.
- **Appendix E**: placement 1 forbids markdown tables in question text (with the raw-pipes rationale); placement 2 is no longer conditional on the UI's capability.

Cost: one extra round trip at `[surface]` and `[candidates]`. The table arrives as readable turn-final text above its question.