### PR TITLE
feat(spawn-ori-eval): enforce the context print with a Claude Code hook ORI-980

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Require context text before the question UI",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/require-question-context.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/require-question-context.py
+++ b/hooks/require-question-context.py
@@ -9,6 +9,13 @@ from pathlib import Path
 from typing import Any
 
 
+RUN_DIRECTORY_PREFIX = "/tmp/spawn-ori-eval-"
+
+
+def has_spawn_eval_marker(records: list[dict[str, Any]]) -> bool:
+    return RUN_DIRECTORY_PREFIX in json.dumps(records)
+
+
 def is_tool_result(record: dict[str, Any]) -> bool:
     message = record.get("message")
     if not isinstance(message, dict) or message.get("role") != "user":
@@ -77,6 +84,9 @@ def main() -> int:
     try:
         records = load_records(Path(transcript_path))
     except OSError:
+        return 0
+
+    if not has_spawn_eval_marker(records):
         return 0
 
     turn_start = len(records)

--- a/hooks/require-question-context.py
+++ b/hooks/require-question-context.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Require assistant text before an AskUserQuestion call."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def is_tool_result(record: dict[str, Any]) -> bool:
+    message = record.get("message")
+    if not isinstance(message, dict) or message.get("role") != "user":
+        return False
+    content = message.get("content")
+    return isinstance(content, list) and any(
+        isinstance(item, dict) and item.get("type") == "tool_result"
+        for item in content
+    )
+
+
+def is_user_turn_start(record: dict[str, Any]) -> bool:
+    message = record.get("message")
+    return (
+        isinstance(message, dict)
+        and message.get("role") == "user"
+        and not is_tool_result(record)
+    )
+
+
+def has_assistant_text(record: dict[str, Any]) -> bool:
+    message = record.get("message")
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return False
+    content = message.get("content")
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(item, dict)
+        and item.get("type") == "text"
+        and isinstance(item.get("text"), str)
+        and item["text"].strip()
+        for item in content
+    )
+
+
+def load_records(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as transcript:
+        for line in transcript:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                records.append(record)
+    return records
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if not isinstance(event, dict):
+        return 0
+
+    if event.get("tool_name") != "AskUserQuestion":
+        return 0
+
+    transcript_path = event.get("transcript_path")
+    if not isinstance(transcript_path, str):
+        return 0
+
+    try:
+        records = load_records(Path(transcript_path))
+    except OSError:
+        return 0
+
+    turn_start = len(records)
+    for index in range(len(records) - 1, -1, -1):
+        if is_user_turn_start(records[index]):
+            turn_start = index
+            break
+
+    if any(has_assistant_text(record) for record in records[turn_start:]):
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        "Print the question context in an assistant text message "
+                        "before asking the user."
+                    ),
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/require-question-context.py
+++ b/hooks/require-question-context.py
@@ -89,7 +89,7 @@ def main() -> int:
     if not has_spawn_eval_marker(records):
         return 0
 
-    turn_start = len(records)
+    turn_start = 0
     for index in range(len(records) - 1, -1, -1):
         if is_user_turn_start(records[index]):
             turn_start = index

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -50,7 +50,7 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 
 ## Claude Code hook
 
-This plugin includes a Claude Code hook for the question UI. It denies a question call when the current turn has no assistant text, so the operator prints the context and retries. Other hosts do not run this hook and rely on the written steps and rules.
+This plugin includes a Claude Code hook for the question UI during `spawn-ori-eval` runs. It denies a question call when the current turn has no assistant text, so the operator prints the context and retries. Other hosts do not run this hook and rely on the written steps and rules.
 
 ## Rules
 

--- a/skills/spawn-ori-eval/SKILL.md
+++ b/skills/spawn-ori-eval/SKILL.md
@@ -48,6 +48,10 @@ Do these in order. One line, one action. Appendix letters point to the detail an
 28. Tell the user where Ori left the temporary workspace and that it is throwaway.
 29. Say they can move the eval into their repo if the numbers made them want to keep it.
 
+## Claude Code hook
+
+This plugin includes a Claude Code hook for the question UI. It denies a question call when the current turn has no assistant text, so the operator prints the context and retries. Other hosts do not run this hook and rely on the written steps and rules.
+
 ## Rules
 
 These hold for the whole run.


### PR DESCRIPTION
## Summary

Written instructions have now failed twice on this. In Jacky's latest export the operator wrote `19 done context printed with table, header row: | Surface | Model today | Code |` into its tracker having copied that header out of the file it read, and emitted no assistant text at all before the question call. The evidence requirement added in #147 was satisfied without the printing it was meant to evidence.

So this stops asking. A `PreToolUse` hook on `AskUserQuestion` reads the transcript, walks back to the start of the current user turn, and denies the call when no assistant text block was emitted in it.

Deny is recoverable rather than fatal, which is what makes it usable. Observed in a real session:

```text
assistant  tool_use     AskUserQuestion
result     Print the question context in an assistant text message before asking the user.
assistant  text         I need to provide context before asking the question...
assistant  tool_use     AskUserQuestion
result     Your questions have been answered: "What would you like to do?"="Work on existing code"
```

A turn that already prints context never sees the hook.

The check is scoped to sessions running this skill by looking for the `/tmp/spawn-ori-eval-` run directory in the transcript, so the plugin does not impose the rule on every question a user's agent asks. It fails open on a malformed event, an unreadable transcript, or a missing marker, because a hook that breaks unrelated sessions is worse than the problem it solves.

## Verified

Claude Code 2.1.220, real sessions, four cases: deny with no preceding text, recovery and pass on retry, no deny when text precedes, and no deny in a session that is not running this skill.

## What this does not fix

The hook binds the host, not the model. `claude-fable-5`, which is what Jacky is running, returns `AskUserQuestion`-shaped JSON as an ordinary text block rather than calling the tool, so no `PreToolUse` event exists to intercept and nothing here can help it. That is a model-side problem and it needs the fable team.

Every other host, Cursor, Codex, Gemini CLI, ignores the hook and still relies on the written steps, which are unchanged.


Link to Devin session: https://openrouter.devinenterprise.com/sessions/d18783d2ee9f498a9d692ead2143be9a
Requested by: @louisgv
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/skills/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->