### PR TITLE
fix(openrouter-models): stop treating output limit as throughput

### DIFF
--- a/skills/openrouter-models/README.md
+++ b/skills/openrouter-models/README.md
@@ -22,8 +22,8 @@ For other install methods (Claude Code plugin marketplace, Cursor Rules, etc.) s
 
 See [SKILL.md](SKILL.md) for the full reference, including:
 
-- Listing and sorting models by newest, price, or throughput (`list-models.ts`)
+- Listing and sorting models by newest, price, or context (`list-models.ts`)
 - Filtering by category (programming, roleplay, vision, etc.)
 - Looking up a specific model's pricing, context length, and modalities
-- Per-provider latency, uptime, and throughput via `get-endpoints.ts`
+- Live per-provider latency, uptime, and throughput via `get-endpoints.ts`
 - Fuzzy model-name resolution

--- a/skills/openrouter-models/SKILL.md
+++ b/skills/openrouter-models/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openrouter-models
-description: Query OpenRouter for available AI models, pricing, capabilities, throughput, and provider performance. Use when the user asks about available OpenRouter models, model pricing, model context lengths, model capabilities, provider latency or uptime, throughput limits, supported parameters, wants to search/filter/compare models, or find the fastest provider for a model.
+description: Query OpenRouter for available AI models, pricing, capabilities, and live provider performance. Use when the user asks about available OpenRouter models, model pricing, model context lengths, model capabilities, provider latency, uptime, or throughput, supported parameters, wants to search/filter/compare models, or find the fastest provider for a model.
 ---
 
 # OpenRouter Models
@@ -26,13 +26,13 @@ Pick the right script based on what the user is asking:
 | See all available models | `list-models.ts` | "What models does OpenRouter have?" |
 | Find recently added models | `list-models.ts --sort newest` | "What are the newest models?" |
 | Find cheapest models | `list-models.ts --sort price` | "What's the cheapest model?" |
-| Find highest throughput models | `list-models.ts --sort throughput` | "Which models have the most output capacity?" |
+| Find largest-context models | `list-models.ts --sort context` | "Which models have the largest context windows?" |
 | Find models in a category | `list-models.ts --category X` | "Best programming models?" |
 | Search by name | `search-models.ts "query"` | "Do they have Claude?" |
 | Resolve an informal model name | `resolve-model.ts "query"` | "Use the nano banana 2.0 model" |
 | Find image-capable models | `search-models.ts --modality image` | "Which models accept images?" |
 | Compare specific models | `compare-models.ts A B` | "Compare Claude vs GPT-4o" |
-| Compare by throughput | `compare-models.ts A B --sort throughput` | "Which has higher throughput, Claude or GPT-4o?" |
+| Compare candidate models by throughput | Run `get-endpoints.ts "model-id" --sort throughput` for each candidate | "Which has higher throughput, Claude or GPT-4o?" |
 | Check provider performance | `get-endpoints.ts "model-id"` | "Which provider is fastest for Claude?" |
 | Find fastest provider | `get-endpoints.ts "model-id" --sort throughput` | "Fastest provider for Claude Sonnet?" |
 | Find lowest-latency provider | `get-endpoints.ts "model-id" --sort latency` | "Lowest latency provider for GPT-4o?" |
@@ -80,7 +80,6 @@ Categories: `programming`, `roleplay`, `marketing`, `marketing/seo`, `technology
 cd <skill-path>/scripts && npx tsx list-models.ts --sort newest      # Recently added first
 cd <skill-path>/scripts && npx tsx list-models.ts --sort price       # Cheapest first
 cd <skill-path>/scripts && npx tsx list-models.ts --sort context     # Largest context first
-cd <skill-path>/scripts && npx tsx list-models.ts --sort throughput  # Most output tokens first
 ```
 
 Models with upcoming `expiration_date` values trigger a stderr warning.
@@ -104,7 +103,9 @@ cd <skill-path>/scripts && npx tsx compare-models.ts "anthropic/claude-sonnet-4"
 cd <skill-path>/scripts && npx tsx compare-models.ts "anthropic/claude-sonnet-4" "openai/gpt-4o" "google/gemini-2.5-pro" --sort price
 ```
 
-Sort options: `price` (cheapest first), `context` (largest first), `speed`/`throughput` (most output tokens first)
+Sort options: `price` (cheapest first), `context` (largest first)
+
+The models list does not contain generation-speed data. `max_completion_tokens` is an output-capacity limit, not throughput.
 
 ## Provider Performance (Endpoints)
 
@@ -117,6 +118,8 @@ cd <skill-path>/scripts && npx tsx get-endpoints.ts "openai/gpt-4o" --sort laten
 ```
 
 Sort options: `throughput` (fastest tokens/sec first), `latency` (lowest p50 ms first), `uptime` (most reliable first), `price` (cheapest first)
+
+Throughput is live and provider-specific. For model-to-model throughput comparisons, run `get-endpoints.ts` once for each model and compare the same percentile, normally p50, from the current results.
 
 Returns for each provider:
 - **Latency** (p50/p75/p90/p99 in ms) — median to worst-case response times
@@ -143,6 +146,7 @@ Returns for each provider:
 - To check modalities, use `model.architecture.input_modalities` / `model.architecture.output_modalities`.
 - Pricing values are per-token in USD as strings — multiply by 1,000,000 for per-million-token pricing.
 - `knowledge_cutoff` and `expiration_date` are date strings or null.
+- `top_provider.max_completion_tokens` is an output-capacity limit. It does not measure tokens per second and must not be used as a throughput proxy.
 - `links.details` points to the per-provider endpoints API for that model. `GET /api/v1/models/{author}/{slug}/endpoints` returns `{ data: { id, name, endpoints: Endpoint[] } }`.
 - Endpoint `status`: `0` = operational, non-zero = degraded.
 - Endpoint `latency_last_30m` / `throughput_last_30m`: percentile objects with `p50`, `p75`, `p90`, `p99`.
@@ -206,7 +210,7 @@ A subset of the raw API fields — the scripts run `formatModel()` which drops `
 |---|---|
 | `pricing.prompt` / `pricing.completion` | Cost per token in USD. Multiply by 1,000,000 for per-million-token pricing |
 | `context_length` | Max total tokens (input + output) |
-| `top_provider.max_completion_tokens` | Max output tokens from the best provider |
+| `top_provider.max_completion_tokens` | Max output tokens from the best provider; an output-capacity limit, not generation speed |
 | `top_provider.is_moderated` | Whether content moderation is applied |
 | `per_request_limits` | Per-request token limits (when non-null) |
 | `supported_parameters` | API parameters the model accepts (e.g., `tools`, `structured_outputs`, `reasoning`, `web_search_options`) |
@@ -221,7 +225,8 @@ A subset of the raw API fields — the scripts run `formatModel()` which drops `
 - When a user mentions a model by informal name, use `resolve-model.ts` first, then feed the resolved `id` into other scripts
 - Convert pricing to per-million-tokens format for readability
 - When comparing, use a markdown table with models as columns
-- For provider endpoints, highlight the fastest (lowest p50 latency) and most reliable (highest uptime) providers
+- For provider endpoints, report generation speed from `throughput_30m_tokens_per_sec` and response latency from `latency_30m_ms`; do not conflate them
+- When comparing throughput across models, use the same live endpoint percentile for each model and never infer speed from `max_completion_tokens`
 - Call out notable supported parameters: `tools`, `structured_outputs`, `reasoning`, `web_search_options`
 - Note cache pricing when available — it can cut input costs 90%+
 - Flag models with `expiration_date` as deprecated

--- a/skills/openrouter-models/scripts/compare-models.ts
+++ b/skills/openrouter-models/scripts/compare-models.ts
@@ -1,8 +1,24 @@
-import { optionalApiKey, fetchApi, parseArgs } from "./lib.js";
+import { optionalApiKey, fetchApi, parseArgs, validateModelSort } from "./lib.js";
+
+const help =
+  "Usage: compare-models.ts <model-id-1> <model-id-2> [...] [--sort price|context]\n\n" +
+  "Examples:\n" +
+  '  npx tsx compare-models.ts "anthropic/claude-sonnet-4" "openai/gpt-4o"\n' +
+  '  npx tsx compare-models.ts "anthropic/claude-sonnet-4" "google/gemini-2.5-pro" --sort price\n\n' +
+  "Sort options:\n" +
+  "  price   - Sort by prompt cost (cheapest first)\n" +
+  "  context - Sort by context length (largest first)\n\n" +
+  "Throughput is live, provider-specific performance data.\n" +
+  'Use get-endpoints.ts "<model-id>" --sort throughput for each model.';
 
 const apiKey = optionalApiKey();
 const args = parseArgs(process.argv.slice(2));
 const sortBy = args.get("sort") as string | undefined;
+
+if (args.has("help")) {
+  console.log(help);
+  process.exit(0);
+}
 
 // Collect positional args as model IDs
 const modelIds: string[] = [];
@@ -13,19 +29,11 @@ for (let i = 0; ; i++) {
 }
 
 if (modelIds.length < 2) {
-  console.error(
-    "Usage: compare-models.ts <model-id-1> <model-id-2> [...] [--sort price|context|speed|throughput]\n\n" +
-      "Examples:\n" +
-      '  npx tsx compare-models.ts "anthropic/claude-sonnet-4" "openai/gpt-4o"\n' +
-      '  npx tsx compare-models.ts "anthropic/claude-sonnet-4" "google/gemini-2.5-pro" --sort price\n\n' +
-      "Sort options:\n" +
-      "  price      - Sort by prompt cost (cheapest first)\n" +
-      "  context    - Sort by context length (largest first)\n" +
-      "  speed      - Sort by max completion tokens (largest first)\n" +
-      "  throughput - Alias for speed"
-  );
+  console.error(help);
   process.exit(1);
 }
+
+validateModelSort(sortBy, ["price", "context"]);
 
 const json = await fetchApi("/models", apiKey);
 const allModels = json.data ?? [];
@@ -62,11 +70,6 @@ if (sortBy === "price") {
   matched.sort((a: any, b: any) => parseFloat(a.pricing?.prompt ?? "0") - parseFloat(b.pricing?.prompt ?? "0"));
 } else if (sortBy === "context") {
   matched.sort((a: any, b: any) => (b.context_length ?? 0) - (a.context_length ?? 0));
-} else if (sortBy === "speed" || sortBy === "throughput") {
-  matched.sort(
-    (a: any, b: any) =>
-      (b.top_provider?.max_completion_tokens ?? 0) - (a.top_provider?.max_completion_tokens ?? 0)
-  );
 }
 
 const comparison = matched.map((m: any) => {

--- a/skills/openrouter-models/scripts/lib.ts
+++ b/skills/openrouter-models/scripts/lib.ts
@@ -60,6 +60,26 @@ export function formatModel(m: any) {
   };
 }
 
+export function validateModelSort(
+  sort: string | undefined,
+  availableSorts: readonly string[]
+): void {
+  if (!sort || availableSorts.includes(sort)) return;
+
+  if (sort === "speed" || sort === "throughput") {
+    console.error(
+      `Error: --sort ${sort} is not available for model-level results.\n` +
+        "Throughput is live, provider-specific performance data, not output capacity.\n" +
+        'Use get-endpoints.ts "<model-id>" --sort throughput for each model.'
+    );
+  } else {
+    console.error(
+      `Error: Unknown sort option "${sort}". Available: ${availableSorts.join(", ")}`
+    );
+  }
+  process.exit(1);
+}
+
 export function parseArgs(argv: string[]): Map<string, string | true> {
   const result = new Map<string, string | true>();
   const positional: string[] = [];

--- a/skills/openrouter-models/scripts/list-models.ts
+++ b/skills/openrouter-models/scripts/list-models.ts
@@ -1,9 +1,31 @@
-import { optionalApiKey, fetchApi, formatModel, parseArgs } from "./lib.js";
+import {
+  optionalApiKey,
+  fetchApi,
+  formatModel,
+  parseArgs,
+  validateModelSort,
+} from "./lib.js";
+
+const help =
+  "Usage: list-models.ts [--category category] [--sort newest|price|context]\n\n" +
+  "Sort options:\n" +
+  "  newest  - Recently added models first\n" +
+  "  price   - Lowest prompt cost first\n" +
+  "  context - Largest context length first\n\n" +
+  "Throughput is live, provider-specific performance data.\n" +
+  'Use get-endpoints.ts "<model-id>" --sort throughput for each candidate model.';
 
 const apiKey = optionalApiKey();
 const args = parseArgs(process.argv.slice(2));
 const category = args.get("category") as string | undefined;
 const sort = args.get("sort") as string | undefined;
+
+if (args.has("help")) {
+  console.log(help);
+  process.exit(0);
+}
+
+validateModelSort(sort, ["newest", "price", "context"]);
 
 const path = category
   ? `/models?category=${encodeURIComponent(category)}`
@@ -26,10 +48,6 @@ if (sort === "newest") {
   models.sort((a: any, b: any) => parseFloat(a.pricing?.prompt ?? "0") - parseFloat(b.pricing?.prompt ?? "0"));
 } else if (sort === "context") {
   models.sort((a: any, b: any) => (b.context_length ?? 0) - (a.context_length ?? 0));
-} else if (sort === "throughput" || sort === "speed") {
-  models.sort((a: any, b: any) =>
-    (b.top_provider?.max_completion_tokens ?? 0) - (a.top_provider?.max_completion_tokens ?? 0)
-  );
 }
 
 console.log(JSON.stringify(models, null, 2));

--- a/skills/openrouter-models/scripts/package.json
+++ b/skills/openrouter-models/scripts/package.json
@@ -2,6 +2,9 @@
   "name": "openrouter-models-scripts",
   "type": "module",
   "private": true,
+  "scripts": {
+    "test": "tsx --test test/*.test.ts"
+  },
   "devDependencies": {
     "tsx": "^4.0.0"
   }

--- a/skills/openrouter-models/scripts/test/fixtures/output-capacity-is-not-throughput.json
+++ b/skills/openrouter-models/scripts/test/fixtures/output-capacity-is-not-throughput.json
@@ -63,15 +63,7 @@
             "quantization": "unknown",
             "supports_implicit_caching": false,
             "supported_parameters": ["max_tokens"]
-          }
-        ]
-      }
-    },
-    "example/small-output-fast": {
-      "data": {
-        "id": "example/small-output-fast",
-        "name": "Small Output, Fast Generation",
-        "endpoints": [
+          },
           {
             "provider_name": "Speed Provider",
             "tag": "speed-provider",
@@ -79,9 +71,9 @@
             "uptime_last_30m": 99.9,
             "latency_last_30m": { "p50": 300, "p75": 400, "p90": 500, "p99": 700 },
             "throughput_last_30m": { "p50": 120, "p75": 130, "p90": 140, "p99": 160 },
-            "context_length": 32768,
+            "context_length": 262144,
             "max_completion_tokens": 4096,
-            "max_prompt_tokens": 32768,
+            "max_prompt_tokens": 262144,
             "pricing": { "prompt": "0.000001", "completion": "0.000002" },
             "quantization": "unknown",
             "supports_implicit_caching": false,

--- a/skills/openrouter-models/scripts/test/fixtures/output-capacity-is-not-throughput.json
+++ b/skills/openrouter-models/scripts/test/fixtures/output-capacity-is-not-throughput.json
@@ -1,0 +1,94 @@
+{
+  "models": {
+    "data": [
+      {
+        "id": "example/large-output-slow",
+        "name": "Large Output, Slow Generation",
+        "created": 1,
+        "context_length": 262144,
+        "pricing": {
+          "prompt": "0.000001",
+          "completion": "0.000002"
+        },
+        "architecture": {
+          "input_modalities": ["text"],
+          "output_modalities": ["text"]
+        },
+        "top_provider": {
+          "max_completion_tokens": 131072,
+          "is_moderated": false
+        },
+        "per_request_limits": null,
+        "supported_parameters": ["max_tokens"]
+      },
+      {
+        "id": "example/small-output-fast",
+        "name": "Small Output, Fast Generation",
+        "created": 2,
+        "context_length": 32768,
+        "pricing": {
+          "prompt": "0.000001",
+          "completion": "0.000002"
+        },
+        "architecture": {
+          "input_modalities": ["text"],
+          "output_modalities": ["text"]
+        },
+        "top_provider": {
+          "max_completion_tokens": 4096,
+          "is_moderated": false
+        },
+        "per_request_limits": null,
+        "supported_parameters": ["max_tokens"]
+      }
+    ]
+  },
+  "endpoints_by_model": {
+    "example/large-output-slow": {
+      "data": {
+        "id": "example/large-output-slow",
+        "name": "Large Output, Slow Generation",
+        "endpoints": [
+          {
+            "provider_name": "Capacity Provider",
+            "tag": "capacity-provider",
+            "status": 0,
+            "uptime_last_30m": 99.9,
+            "latency_last_30m": { "p50": 900, "p75": 1000, "p90": 1200, "p99": 1600 },
+            "throughput_last_30m": { "p50": 12, "p75": 14, "p90": 16, "p99": 20 },
+            "context_length": 262144,
+            "max_completion_tokens": 131072,
+            "max_prompt_tokens": 262144,
+            "pricing": { "prompt": "0.000001", "completion": "0.000002" },
+            "quantization": "unknown",
+            "supports_implicit_caching": false,
+            "supported_parameters": ["max_tokens"]
+          }
+        ]
+      }
+    },
+    "example/small-output-fast": {
+      "data": {
+        "id": "example/small-output-fast",
+        "name": "Small Output, Fast Generation",
+        "endpoints": [
+          {
+            "provider_name": "Speed Provider",
+            "tag": "speed-provider",
+            "status": 0,
+            "uptime_last_30m": 99.9,
+            "latency_last_30m": { "p50": 300, "p75": 400, "p90": 500, "p99": 700 },
+            "throughput_last_30m": { "p50": 120, "p75": 130, "p90": 140, "p99": 160 },
+            "context_length": 32768,
+            "max_completion_tokens": 4096,
+            "max_prompt_tokens": 32768,
+            "pricing": { "prompt": "0.000001", "completion": "0.000002" },
+            "quantization": "unknown",
+            "supports_implicit_caching": false,
+            "supported_parameters": ["max_tokens"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/skills/openrouter-models/scripts/test/mock-fetch.mjs
+++ b/skills/openrouter-models/scripts/test/mock-fetch.mjs
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+
+const fixturePath = new URL(
+  process.env.OPENROUTER_MODELS_TEST_FIXTURE ??
+    "./fixtures/output-capacity-is-not-throughput.json",
+  import.meta.url
+);
+const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+
+globalThis.fetch = async (input) => {
+  const url = new URL(String(input));
+  let body;
+
+  if (url.pathname === "/api/v1/models") {
+    body = fixture.models;
+  } else {
+    const match = url.pathname.match(/^\/api\/v1\/models\/(.+)\/endpoints$/);
+    const modelId = match?.[1];
+    body = modelId ? fixture.endpoints_by_model[modelId] : undefined;
+  }
+
+  if (!body) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return Response.json(body);
+};

--- a/skills/openrouter-models/scripts/test/throughput-sorting.test.ts
+++ b/skills/openrouter-models/scripts/test/throughput-sorting.test.ts
@@ -71,30 +71,25 @@ test("compare-models help routes throughput comparisons to live endpoints", () =
   assert.match(result.stdout, /get-endpoints\.ts/);
 });
 
-test("the live endpoint fixture ranks generation speed independently of output capacity", () => {
-  const largeOutput = runScript("get-endpoints.ts", [
+test("throughput sorting puts the faster endpoint before the higher-capacity endpoint", () => {
+  const result = runScript("get-endpoints.ts", [
     "example/large-output-slow",
     "--sort",
     "throughput",
   ]);
-  const fastOutput = runScript("get-endpoints.ts", [
-    "example/small-output-fast",
-    "--sort",
-    "throughput",
-  ]);
 
-  assert.equal(largeOutput.status, 0, largeOutput.stderr);
-  assert.equal(fastOutput.status, 0, fastOutput.stderr);
+  assert.equal(result.status, 0, result.stderr);
 
-  const largeOutputEndpoint = JSON.parse(largeOutput.stdout).endpoints[0];
-  const fastOutputEndpoint = JSON.parse(fastOutput.stdout).endpoints[0];
+  const [fastEndpoint, highCapacityEndpoint] = JSON.parse(result.stdout).endpoints;
 
+  assert.equal(fastEndpoint.provider, "Speed Provider");
+  assert.equal(highCapacityEndpoint.provider, "Capacity Provider");
   assert.ok(
-    largeOutputEndpoint.max_completion_tokens > fastOutputEndpoint.max_completion_tokens
+    fastEndpoint.max_completion_tokens < highCapacityEndpoint.max_completion_tokens
   );
   assert.ok(
-    largeOutputEndpoint.throughput_30m_tokens_per_sec.p50 <
-      fastOutputEndpoint.throughput_30m_tokens_per_sec.p50
+    fastEndpoint.throughput_30m_tokens_per_sec.p50 >
+      highCapacityEndpoint.throughput_30m_tokens_per_sec.p50
   );
 });
 

--- a/skills/openrouter-models/scripts/test/throughput-sorting.test.ts
+++ b/skills/openrouter-models/scripts/test/throughput-sorting.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const scriptsDir = fileURLToPath(new URL("..", import.meta.url));
+const mockFetch = fileURLToPath(new URL("./mock-fetch.mjs", import.meta.url));
+
+function runScript(script: string, args: string[]) {
+  return spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--import", mockFetch, script, ...args],
+    {
+      cwd: scriptsDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENROUTER_API_KEY: "test-key",
+      },
+    }
+  );
+}
+
+test("list-models refuses to rank output capacity as throughput or speed", () => {
+  for (const sort of ["throughput", "speed"]) {
+    const result = runScript("list-models.ts", ["--sort", sort]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /throughput is live, provider-specific performance data/i);
+    assert.match(result.stderr, /get-endpoints\.ts/);
+  }
+});
+
+test("list-models help advertises only capability sorts", () => {
+  const result = runScript("list-models.ts", ["--help"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /--sort newest\|price\|context/);
+  assert.doesNotMatch(
+    result.stdout,
+    /Usage: list-models\.ts[^\n]*(?:speed|throughput)/
+  );
+  assert.match(result.stdout, /get-endpoints\.ts/);
+});
+
+test("compare-models refuses to rank output capacity as throughput or speed", () => {
+  for (const sort of ["throughput", "speed"]) {
+    const result = runScript("compare-models.ts", [
+      "example/large-output-slow",
+      "example/small-output-fast",
+      "--sort",
+      sort,
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /throughput is live, provider-specific performance data/i);
+    assert.match(result.stderr, /get-endpoints\.ts/);
+  }
+});
+
+test("compare-models help routes throughput comparisons to live endpoints", () => {
+  const result = runScript("compare-models.ts", ["--help"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /--sort price\|context/);
+  assert.doesNotMatch(
+    result.stdout,
+    /Usage: compare-models\.ts[^\n]*(?:speed|throughput)/
+  );
+  assert.match(result.stdout, /get-endpoints\.ts/);
+});
+
+test("the live endpoint fixture ranks generation speed independently of output capacity", () => {
+  const largeOutput = runScript("get-endpoints.ts", [
+    "example/large-output-slow",
+    "--sort",
+    "throughput",
+  ]);
+  const fastOutput = runScript("get-endpoints.ts", [
+    "example/small-output-fast",
+    "--sort",
+    "throughput",
+  ]);
+
+  assert.equal(largeOutput.status, 0, largeOutput.stderr);
+  assert.equal(fastOutput.status, 0, fastOutput.stderr);
+
+  const largeOutputEndpoint = JSON.parse(largeOutput.stdout).endpoints[0];
+  const fastOutputEndpoint = JSON.parse(fastOutput.stdout).endpoints[0];
+
+  assert.ok(
+    largeOutputEndpoint.max_completion_tokens > fastOutputEndpoint.max_completion_tokens
+  );
+  assert.ok(
+    largeOutputEndpoint.throughput_30m_tokens_per_sec.p50 <
+      fastOutputEndpoint.throughput_30m_tokens_per_sec.p50
+  );
+});
+
+test("skill instructions route throughput questions to live endpoint data", () => {
+  const skill = readFileSync(new URL("../../SKILL.md", import.meta.url), "utf8");
+  const readme = readFileSync(new URL("../../README.md", import.meta.url), "utf8");
+
+  assert.doesNotMatch(skill, /list-models\.ts --sort throughput/);
+  assert.doesNotMatch(
+    skill,
+    /compare-models\.ts[^\n`]*--sort throughput/
+  );
+  assert.match(skill, /run `get-endpoints\.ts` once for each model/i);
+  assert.match(readme, /sorting models by newest, price, or context/i);
+});


### PR DESCRIPTION
## Problem

`list-models.ts` and `compare-models.ts` accepted `--sort speed` and `--sort throughput`, but ranked models by `top_provider.max_completion_tokens`. That field is an output-capacity limit, not generation speed, so the commands silently returned the wrong ordering.

Closes #13

## Root cause

The model list response does not contain tokens-per-second performance data. Actual throughput is live and provider-specific under `GET /models/{id}/endpoints`.

## Changes

- Remove model-level speed and throughput sorting from list and compare commands
- Reject the legacy sort names with a direct route to `get-endpoints.ts --sort throughput`
- Keep CLI help and `SKILL.md` guidance aligned on the supported sort modes
- Add reverse-ordered provider endpoints where the lower-output-capacity endpoint generates faster
- Add CLI regression coverage for both removed aliases and the live endpoint workflow

## Testing

- `npm ci`
- `npm test` (6 tests)
- `git diff --check`
- Mutation check: reversing endpoint throughput sorting fails the regression test

## Regression risk

Low. Existing newest, price, and context sorting is unchanged. The intentional compatibility change is that the two misleading sort names now fail with an actionable error instead of returning a false ranking.


## Live acceptance

- On `main`, `list-models.ts --sort throughput` returned 415 live models with a zero exit code. The first models had a 1,800,000-token output limit.
- On this branch, the same command exits with code 1 and directs the user to live endpoint throughput data.
- On `main`, `compare-models.ts ... --sort speed` placed the 1,800,000-token model before the 16,384-token model. On this branch, it rejects that false comparison.
- `list-models.ts --sort context` fetched 415 live models and returned them in descending context-length order.
- The live endpoint API returned provider lists for four current models. Their `throughput_last_30m` values were null, so a numeric live throughput order was not available to observe. The deterministic endpoint fixture covers that data case.


## Installed acceptance

`gh skill install yazcaleb/skills openrouter-models --pin de43c1b` installed the skill into a clean directory. From that installed copy:

- Both removed sort aliases exited with code 1 and printed the `get-endpoints.ts` route.
- The updated help listed only the supported model-level sorts.
- The live models request returned 415 models in descending context-length order.
- The live endpoint request returned three providers for `openai/gpt-4o-mini`.
- Those providers had null 30-minute throughput values, so the live numeric ordering constraint still applies.

